### PR TITLE
Fix tutorial 12

### DIFF
--- a/12_run_tests_before_deploy/pipeline.yml
+++ b/12_run_tests_before_deploy/pipeline.yml
@@ -13,12 +13,8 @@ jobs:
         image: docker:///golang#1.4.2
         inputs:
           - name: resource-web-app
-            path: .
         run:
-          path: go
-          args:
-            - test
-            - ./...
+          path: ./resource-web-app/test
   - aggregate:
     - put: resource-deploy-web-app
       params:

--- a/12_run_tests_before_deploy/pipeline.yml
+++ b/12_run_tests_before_deploy/pipeline.yml
@@ -35,4 +35,3 @@ resources:
     password: {{cf-password}}
     organization: {{cf-organization}}
     space: {{cf-space}}
-    skip_cert_check: {{cf-skip-cert-check}}

--- a/12_run_tests_before_deploy/stub.example.yml
+++ b/12_run_tests_before_deploy/stub.example.yml
@@ -3,4 +3,3 @@ cf-username: EMAIL
 cf-password: PASSWORD
 cf-organization: ORG
 cf-space: SPACE
-cf-skip-cert-check: false


### PR DESCRIPTION
* [x] Switches to using the test script submitted in https://github.com/cloudfoundry-community/simple-go-web-app/pull/1 (fixes #4) - merged
* [ ] Removes the `skip_cert_check` configuration from the CF service, since it can't be parameterized (fixes #8 )