### PR TITLE
Added trigger: true to autostart both jobs after update.

### DIFF
--- a/08_pipeline_jobs/pipeline.yml
+++ b/08_pipeline_jobs/pipeline.yml
@@ -6,6 +6,7 @@ jobs:
   plan:
   - aggregate:
     - get: resource-gist
+      trigger: true
   - task: hello-world
     file: resource-gist/hello-world.yml
 
@@ -15,6 +16,7 @@ jobs:
   plan:
   - aggregate:
     - get: resource-gist
+      trigger: true
       passed: [job-fetch-resource]
   - task: meta
     file: resource-gist/display-other-task.yml


### PR DESCRIPTION
I added trigger: true to both get actions. If you update the gist, the pipeline will work now. 

This will only work if the job is triggered by a gist update. If you manual run the first job the second one will not be executed. 

fix #14 