### PR TITLE
Fix bosh_deploy pipeline by adding stemcells

### DIFF
--- a/45_bosh_deploy/pipeline.yml
+++ b/45_bosh_deploy/pipeline.yml
@@ -13,7 +13,8 @@ jobs:
       manifest: resource-manifest/manifest.yml
       releases:
         - resource-bosh-release-redis/*.tgz
-      stemcells: []
+      stemcells:
+        - resource-bosh-stemcell/*.tgz
 resources:
 - name: resource-manifest
   type: git


### PR DESCRIPTION
I didn't work through all your examples, but instead picked 45 specifically, because it's interesting to me. Maybe this bug wasn't uncovered, because the stemcell is already uploaded in one of the previous examples. Anyway, this fixes it.