### PR TITLE
switch all image: usage to image_resource:

### DIFF
--- a/01_task_hello_world/task_hello_world.yml
+++ b/01_task_hello_world/task_hello_world.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///busybox
+image_resource:
+  type: docker-image
+  source: {repository: busybox}
 
 run:
   path: echo

--- a/01_task_hello_world/task_ubuntu_uname.yml
+++ b/01_task_hello_world/task_ubuntu_uname.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///ubuntu#14.04
+image_resource:
+  type: docker-image
+  source: {repository: ubuntu, tag: "14.04"}
 
 run:
   path: uname

--- a/02_task_inputs/input_parent_dir.yml
+++ b/02_task_inputs/input_parent_dir.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///busybox
+image_resource:
+  type: docker-image
+  source: {repository: busybox}
 
 inputs:
 - name: 02_task_inputs

--- a/02_task_inputs/inputs_required.yml
+++ b/02_task_inputs/inputs_required.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///busybox
+image_resource:
+  type: docker-image
+  source: {repository: busybox}
 
 inputs:
 - name: some-important-input

--- a/02_task_inputs/no_inputs.yml
+++ b/02_task_inputs/no_inputs.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///busybox
+image_resource:
+  type: docker-image
+  source: {repository: busybox}
 
 run:
   path: ls

--- a/03_task_scripts/task_show_uname.yml
+++ b/03_task_scripts/task_show_uname.yml
@@ -1,5 +1,9 @@
+---
 platform: linux
-image: docker:///busybox
+
+image_resource:
+  type: docker-image
+  source: {repository: busybox}
 
 inputs:
 - name: 03_task_scripts

--- a/04_basic_pipeline/pipeline.yml
+++ b/04_basic_pipeline/pipeline.yml
@@ -6,7 +6,9 @@ jobs:
   - task: hello-world
     config:
       platform: linux
-      image: docker:///busybox
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
       run:
         path: echo
         args: [hello world]

--- a/10_job_inputs/task_run_tests.yml
+++ b/10_job_inputs/task_run_tests.yml
@@ -1,12 +1,9 @@
 ---
 platform: linux
 
-image: docker:///golang#1.6-alpine
-# image_resource:
-#   type: docker-image
-#   source:
-#     repository: golang
-#     tag: '1.6-alpine'
+image_resource:
+  type: docker-image
+  source: {repository: golang, tag: 1.6-alpine}
 
 inputs:
 - name: resource-tutorial
@@ -14,6 +11,4 @@ inputs:
   path: gopath/src/github.com/cloudfoundry-community/simple-go-web-app
 
 run:
-  # path: ls
-  # args: [-alR]
   path: resource-tutorial/10_job_inputs/task_run_tests.sh

--- a/11_task_inputs_bonus/README.md
+++ b/11_task_inputs_bonus/README.md
@@ -53,7 +53,9 @@ The task `ls-abc-xyz` declares explicitly that it wants both resources via its `
 - task: ls-abc-xyz
   config:
     platform: linux
-    image: docker:///ubuntu#14.04
+    image_resource:
+      type: docker-image
+      source: {repository: ubuntu, tag: "14.04"}
     inputs:
     - name: gist-abc
     - name: gist-xyz
@@ -69,7 +71,7 @@ We can demonstrate that a task only has access to resource inputs that it specif
 ```
 $ run.sh ls-abc
 ...
-initializing with docker:///ubuntu#14.04
+initializing
 running ls -opR .
 .:
 total 4
@@ -88,7 +90,7 @@ Bonus - pretty print via resource script
 ```
 $ ./run.sh pretty-ls
 ...
-initializing with docker:///ubuntu#14.04
+initializing
 running bash pretty-ls/pretty_ls.sh .
 ./gist-abc
 ./gist-xyz
@@ -100,7 +102,7 @@ running bash pretty-ls/pretty_ls.sh .
 ./gist-xyz/y.md
 ./gist-xyz/z.md
 ./pretty-ls/pretty_ls.sh
-initializing with docker:///ubuntu#14.04
+initializing
 running bash pretty-ls/pretty_ls.sh .
 ./gist-xyz
 ./pretty-ls

--- a/11_task_inputs_bonus/pipeline-ls-abc-xyz.yml
+++ b/11_task_inputs_bonus/pipeline-ls-abc-xyz.yml
@@ -10,7 +10,9 @@ jobs:
   - task: ls-abc-xyz
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: gist-abc
       - name: gist-xyz

--- a/11_task_inputs_bonus/pipeline-ls-abc.yml
+++ b/11_task_inputs_bonus/pipeline-ls-abc.yml
@@ -9,7 +9,9 @@ jobs:
   - task: ls-abc
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: gist-abc
       run:

--- a/11_task_inputs_bonus/pipeline-pretty-ls.yml
+++ b/11_task_inputs_bonus/pipeline-pretty-ls.yml
@@ -10,7 +10,9 @@ jobs:
   - task: pretty-ls-abc-xyz
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: pretty-ls
       - name: gist-abc
@@ -21,7 +23,9 @@ jobs:
   - task: pretty-ls-xyz
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: pretty-ls
       - name: gist-xyz

--- a/11_task_outputs_to_inputs/create_some_files.yml
+++ b/11_task_outputs_to_inputs/create_some_files.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///busybox
+image_resource:
+  type: docker-image
+  source: {repository: busybox}
 
 inputs:
 - name: resource-tutorial

--- a/11_task_outputs_to_inputs/show_files.yml
+++ b/11_task_outputs_to_inputs/show_files.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///busybox
+image_resource:
+  type: docker-image
+  source: {repository: busybox}
 
 inputs:
 - name: resource-tutorial

--- a/12_publishing_outputs/bump-timestamp-file.yml
+++ b/12_publishing_outputs/bump-timestamp-file.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///concourse/concourse-ci
+image_resource:
+  type: docker-image
+  source: {repository: concourse/concourse-ci}
 
 inputs:
   - name: resource-tutorial

--- a/13_pipeline_jobs/pipeline.params.yml
+++ b/13_pipeline_jobs/pipeline.params.yml
@@ -31,7 +31,9 @@ jobs:
   - task: show-date
     config:
       platform: linux
-      image: docker:///busybox
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
       inputs:
         - name: resource-gist
       run:

--- a/13_pipeline_jobs/pipeline.yml
+++ b/13_pipeline_jobs/pipeline.yml
@@ -31,7 +31,9 @@ jobs:
   - task: show-date
     config:
       platform: linux
-      image: docker:///busybox
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
       inputs:
         - name: resource-gist
       run:

--- a/14_parameters/pipeline.yml
+++ b/14_parameters/pipeline.yml
@@ -31,7 +31,9 @@ jobs:
   - task: show-date
     config:
       platform: linux
-      image: docker:///busybox
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
       inputs:
         - name: resource-gist
       run:

--- a/20_versions_and_buildnumbers/README.md
+++ b/20_versions_and_buildnumbers/README.md
@@ -91,7 +91,9 @@ jobs:
   - task: display-version
     config:
       platform: linux
-      image: docker:///busybox
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
       inputs:
       - name: resource-version
       run:

--- a/20_versions_and_buildnumbers/pipeline-bump.yml
+++ b/20_versions_and_buildnumbers/pipeline-bump.yml
@@ -20,7 +20,9 @@ jobs:
   - task: display-version
     config:
       platform: linux
-      image: docker:///busybox
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
       inputs:
       - name: resource-version
       run:

--- a/20_versions_and_buildnumbers/pipeline-display-version.yml
+++ b/20_versions_and_buildnumbers/pipeline-display-version.yml
@@ -19,7 +19,9 @@ jobs:
   - task: display-version
     config:
       platform: linux
-      image: docker:///busybox
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
       inputs:
       - name: resource-version
       run:

--- a/40_github_release_input/README.md
+++ b/40_github_release_input/README.md
@@ -42,7 +42,7 @@ Also included are files `tag` and `version`.
 The example job also outputs the contents of this file:
 
 ```
-initializing with docker:///ubuntu#14.04
+initializing
 running cat github-release-spiff/version
 1.0.6
 ```

--- a/40_github_release_input/pipeline.yml
+++ b/40_github_release_input/pipeline.yml
@@ -7,7 +7,9 @@ jobs:
   - task: ls
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: github-release-spiff
       run:
@@ -16,7 +18,9 @@ jobs:
   - task: version
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: github-release-spiff
       run:

--- a/44_bosh_io/pipeline.yml
+++ b/44_bosh_io/pipeline.yml
@@ -13,7 +13,9 @@ jobs:
   - task: ls
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: bosh-stemcell-aws
       - name: bosh-release-redis
@@ -23,7 +25,9 @@ jobs:
   - task: files-bosh-stemcell-aws
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: bosh-stemcell-aws
       run:
@@ -32,7 +36,9 @@ jobs:
   - task: files-bosh-release-redis
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: bosh-release-redis
       run:

--- a/46_bosh_manifest_spiff_merge/pipeline-base-save.yml
+++ b/46_bosh_manifest_spiff_merge/pipeline-base-save.yml
@@ -14,7 +14,9 @@ jobs:
   - task: spiff-merge
     config:
       platform: linux
-      image: docker:///drnic/spiff
+      image_resource:
+        type: docker-image
+        source: {repository: drnic/spiff}
       inputs:
       - name: redis-release
       - name: stub
@@ -29,7 +31,9 @@ jobs:
   - task: show-manifest
     config:
       platform: linux
-      image: docker:///drnic/spiff
+      image_resource:
+        type: docker-image
+        source: {repository: drnic/spiff}
       inputs:
       - name: spiff-merge
       run:

--- a/46_bosh_manifest_spiff_merge/pipeline-base-show.yml
+++ b/46_bosh_manifest_spiff_merge/pipeline-base-show.yml
@@ -14,14 +14,18 @@ jobs:
   - task: spiff-help
     config:
       platform: linux
-      image: docker:///drnic/spiff
+      image_resource:
+        type: docker-image
+        source: {repository: drnic/spiff}
       run:
         path: spiff
         args: ["-h"]
   - task: spiff-merge
     config:
       platform: linux
-      image: docker:///drnic/spiff
+      image_resource:
+        type: docker-image
+        source: {repository: drnic/spiff}
       inputs:
       - name: redis-release
       - name: stub

--- a/47_spiff_merge_redis_to_bosh_lite/credentials.example.yml
+++ b/47_spiff_merge_redis_to_bosh_lite/credentials.example.yml
@@ -7,7 +7,7 @@ docker-hub-email: EMAIL
 docker-hub-username: USERNAME
 docker-hub-password: PASSWORD
 docker-hub-image-47-tasks: drnic/concourse-tutorial-47-tasks
-docker-hub-image-47-tasks-uri: docker:///USERNAME/concourse-tutorial-47-tasks
+docker-hub-image-47-tasks-repository: USERNAME/concourse-tutorial-47-tasks
 github_private_key: |
   -----BEGIN RSA PRIVATE KEY-----
   MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W

--- a/47_spiff_merge_redis_to_bosh_lite/pipeline-bosh-deploy.yml
+++ b/47_spiff_merge_redis_to_bosh_lite/pipeline-bosh-deploy.yml
@@ -19,7 +19,9 @@ jobs:
   - task: spiff-merge
     config:
       platform: linux
-      image: {{docker-hub-image-47-tasks-uri}}
+      image_resource:
+        type: docker-image
+        source: {repository: {{docker-hub-image-47-tasks-image}}}
       inputs:
       - name: stub
       - name: redis-release
@@ -35,7 +37,9 @@ jobs:
   - task: git-add
     config:
       platform: linux
-      image: {{docker-hub-image-47-tasks-uri}}
+      image_resource:
+        type: docker-image
+        source: {repository: {{docker-hub-image-47-tasks-image}}}
       inputs:
       - name: spiff-merge
       run:

--- a/60_multi_jobs_bosh_micro_build/pipeline-build-cli.yml
+++ b/60_multi_jobs_bosh_micro_build/pipeline-build-cli.yml
@@ -10,7 +10,9 @@ jobs:
   - task: bosh-init-cli-build
     config:
       platform: linux
-      image: docker:///concourse/static-golang
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/static-golang}
       inputs:
         - name: bosh-init
           path: gopath/src/github.com/cloudfoundry/bosh-init
@@ -19,7 +21,9 @@ jobs:
   - task: ls
     config:
       platform: linux
-      image: docker:///ubuntu#14.04
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu, tag: "14.04"}
       inputs:
       - name: bosh-init-cli-build
       run:

--- a/60_multi_jobs_bosh_micro_build/pipeline-build-save.yml
+++ b/60_multi_jobs_bosh_micro_build/pipeline-build-save.yml
@@ -10,7 +10,9 @@ jobs:
   - task: bosh-init-cli-build
     config:
       platform: linux
-      image: docker:///concourse/static-golang
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/static-golang}
       inputs:
         - name: bosh-init
           path: gopath/src/github.com/cloudfoundry/bosh-init

--- a/60_multi_jobs_bosh_micro_build/pipeline-plus-openstack.yml
+++ b/60_multi_jobs_bosh_micro_build/pipeline-plus-openstack.yml
@@ -10,7 +10,9 @@ jobs:
   - task: bosh-init-cli-build
     config:
       platform: linux
-      image: docker:///concourse/static-golang
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/static-golang}
       inputs:
         - name: bosh-init
           path: gopath/src/github.com/cloudfoundry/bosh-init
@@ -32,7 +34,9 @@ jobs:
   - task: prepare-aws-docker-image
     config:
       platform: linux
-      image: docker:///concourse/static-golang
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/static-golang}
       inputs:
         - name: s3-bosh-init
         - name: cpi
@@ -55,7 +59,9 @@ jobs:
   - task: prepare-openstack-docker-image
     config:
       platform: linux
-      image: docker:///concourse/static-golang
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/static-golang}
       inputs:
         - name: s3-bosh-init
         - name: cpi

--- a/60_multi_jobs_bosh_micro_build/pipeline-repackage.yml
+++ b/60_multi_jobs_bosh_micro_build/pipeline-repackage.yml
@@ -10,7 +10,9 @@ jobs:
   - task: bosh-init-cli-build
     config:
       platform: linux
-      image: docker:///concourse/static-golang
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/static-golang}
       inputs:
         - name: bosh-init
           path: gopath/src/github.com/cloudfoundry/bosh-init


### PR DESCRIPTION
image_resource: is better in pretty much every way (aside from
verbosity), and is the only way to do things with the 1.3+ binaries (to
make them more portable by not having to set up Garden's graph dir).

note: I left the tutorial about authoring resource types as-is (still using `docker://`) since that should probably be entirely redone to use [`resource_types`](https://concourse.ci/configuring-resource-types.html) anyway.