### PR TITLE
12 - Task fails due to missing docker image 

### DIFF
--- a/12_publishing_outputs/bump-timestamp-file.yml
+++ b/12_publishing_outputs/bump-timestamp-file.yml
@@ -3,7 +3,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: concourse/concourse-ci}
+  source: {repository: concourse/buildroot, tag: git}
 
 inputs:
   - name: resource-tutorial

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ First, it copied the input resource `resource-gist` into the output resource `up
 
 The `updated-gist` output from the `bump-timestamp-file` task becomes the `updated-gist` input to the `resource-gist` resource (see the [`git` resource](https://github.com/concourse/git-resource) for additional configuration) because their names match.
 
-The `bump-timestamp-file.sh` script needed the `git` CLI tool. It could have installed it each time via `apt-get install git` or similar, but this would have made the task very slow. Instead `bump-timestamp-file.yml` task file uses a different base image `concourse/concourse-ci` that contains `git` CLI (and many other pre-installed packages). The contents of this Docker image are described at https://github.com/concourse/concourse/blob/master/ci/dockerfiles/concourse-ci/Dockerfile
+The `bump-timestamp-file.sh` script needed the `git` CLI tool. It could have installed it each time via `apt-get install git` or similar, but this would have made the task very slow. Instead `bump-timestamp-file.yml` task file uses a different base image `concourse/buildroot` that contains the `git` CLI (and many other pre-installed packages). The contents of this Docker image are described at https://github.com/concourse/concourse/blob/master/ci/dockerfiles/concourse-ci/Dockerfile
 
 ### 13 - Actual pipeline - passing resources between jobs
 


### PR DESCRIPTION
The `concourse/concourse-ci` docker image apparently no longer exists.