### PR TITLE
The concourse/concourse-ci Docker image went away. 

### DIFF
--- a/12_publishing_outputs/bump-timestamp-file.yml
+++ b/12_publishing_outputs/bump-timestamp-file.yml
@@ -3,7 +3,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: concourse/concourse-ci}
+  source: { repository: concourse/bosh-cli }
 
 inputs:
   - name: resource-tutorial


### PR DESCRIPTION
Found a short-term alternative. We'll want to revisit this and create our own. This at least fixes the broken tutorial segment.