### PR TITLE
Update steps 46&47 to use master branch.

### DIFF
--- a/46_bosh_manifest_spiff_merge/pipeline-base-save.yml
+++ b/46_bosh_manifest_spiff_merge/pipeline-base-save.yml
@@ -54,7 +54,7 @@ resources:
   type: git
   source:
     uri: https://github.com/starkandwayne/concourse-tutorial.git
-    branch: fix-46-spiff-merge
+    branch: master
 
 - name: resource-deployment-manifest-stub
   type: git

--- a/47_spiff_merge_redis_to_bosh_lite/pipeline-build-task-image.yml
+++ b/47_spiff_merge_redis_to_bosh_lite/pipeline-build-task-image.yml
@@ -15,7 +15,7 @@ resources:
   type: git
   source:
     uri: https://github.com/starkandwayne/concourse-tutorial.git
-    branch: fix-46-spiff-merge
+    branch: master
 
 - name: task-docker-image
   type: docker-image


### PR DESCRIPTION
These two manifests had to use branch `fix-46-spiff-merge` until the fixes were actually merged to master. Now that #74 has been merged in it's safe to point these back at `master`.