### PR TITLE
Added CI for the tutorial itself.

### DIFF
--- a/35_push_docker_image/run.sh
+++ b/35_push_docker_image/run.sh
@@ -1,33 +1,27 @@
 #!/bin/bash
 
-
-if [ -e "./credentials.yml" ]; then
-  stub="./credentials.yml"
-else
-  stub=$1; shift
-fi
-
-set -uex
+set -ex
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-export ATC_URL=${ATC_URL:-"http://192.168.100.4:8080"}
 export fly_target=${fly_target:-tutorial}
 echo "Concourse API target ${fly_target}"
-echo "Concourse API $ATC_URL"
 echo "Tutorial $(basename $DIR)"
 
 realpath() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-if [[ "${stub}X" == "X" ]]; then
+usage() {
   echo "USAGE: run.sh path/to/credentials.yml"
   exit 1
+}
+
+if [ -z "${stub}" ]; then
+  stub="../credentials.yml"
 fi
 stub=$(realpath $stub)
 if [[ ! -f ${stub} ]]; then
-  echo "USAGE: run.sh path/to/credentials.yml"
-  exit 1
+  usage
 fi
 
 pushd $DIR

--- a/36_pull_docker_image/run.sh
+++ b/36_pull_docker_image/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ -e "./credentials.yml" ]; then
-  stub="./credentials.yml"
+if [ -e "../credentials.yml" ]; then
+  stub="../credentials.yml"
 else
   stub=$1; shift
 fi

--- a/45_bosh_deploy/README.md
+++ b/45_bosh_deploy/README.md
@@ -20,7 +20,7 @@ The `credentials.yml` now needs the target and credentials for a BOSH:
 
 ```yaml
 ---
-bosh-target: https://54.2.3.4:25555
+bosh-director: https://54.2.3.4:25555
 bosh-username: admin
 bosh-password: admin
 bosh-stemcell-name: bosh-warden-boshlite-ubuntu-trusty-go_agent
@@ -53,7 +53,7 @@ For a normal BOSH with built-in SSL, you will need to set `source.ignore_ssl` to
 - name: resource-redis-bosh-deployment
   type: bosh-deployment
   source:
-    target: bosh-target
+    target: bosh-director
     username: bosh-username
     password: bosh-password
     deployment: redis

--- a/45_bosh_deploy/credentials.example.yml
+++ b/45_bosh_deploy/credentials.example.yml
@@ -1,5 +1,5 @@
 ---
-bosh-target: https://54.2.3.4:25555
+bosh-director: https://54.2.3.4:25555
 bosh-username: admin
 bosh-password: admin
 bosh-stemcell-name: bosh-warden-boshlite-ubuntu-trusty-go_agent

--- a/45_bosh_deploy/pipeline.yml
+++ b/45_bosh_deploy/pipeline.yml
@@ -35,7 +35,7 @@ resources:
 - name: resource-redis-bosh-deployment
   type: bosh-deployment
   source:
-    target: {{bosh-target}}
+    target: {{bosh-director}}
     username: {{bosh-username}}
     password: {{bosh-password}}
     deployment: redis # from the manifest.yml in resource-manifest

--- a/46_bosh_manifest_spiff_merge/run.sh
+++ b/46_bosh_manifest_spiff_merge/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-
-# set -ex
+set -e
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 export ATC_URL=${ATC_URL:-"http://192.168.100.4:8080"}
@@ -19,16 +18,16 @@ usage() {
   exit 1
 }
 
-stage=$1; shift
+stage=$1
 if [ -z "${stage}" ]; then
   ./run.sh show
-  # ./run.sh save
+  ./run.sh save
   exit 0
 elif [[ "${stage}" != "show" && "${stage}" != "save" ]]; then
   usage
 fi
 
-echo bar
+echo "Stage: ${stage}"
 
 pushd $DIR
   fly sp -t ${fly_target} configure -c pipeline-base-${stage}.yml -p main -n

--- a/47_spiff_merge_redis_to_bosh_lite/README.md
+++ b/47_spiff_merge_redis_to_bosh_lite/README.md
@@ -20,7 +20,7 @@ The `credentials.yml` now needs the target and credentials for a BOSH:
 
 ```yaml
 ---
-bosh-target: https://54.2.3.4:25555
+bosh-director: https://54.2.3.4:25555
 bosh-username: admin
 bosh-password: admin
 bosh-stemcell-name: bosh-warden-boshlite-ubuntu-trusty-go_agent
@@ -47,7 +47,7 @@ For a normal BOSH with built-in SSL, you will need to set `source.ignore_ssl` to
 - name: resource-redis-bosh-deployment
   type: bosh-deployment
   source:
-    target: bosh-target
+    target: bosh-director
     username: bosh-username
     password: bosh-password
     deployment: redis

--- a/47_spiff_merge_redis_to_bosh_lite/credentials.example.yml
+++ b/47_spiff_merge_redis_to_bosh_lite/credentials.example.yml
@@ -1,5 +1,5 @@
 ---
-bosh-target: https://54.2.3.4:25555
+bosh-director: https://54.2.3.4:25555
 bosh-username: admin
 bosh-password: admin
 bosh-stemcell-name: bosh-warden-boshlite-ubuntu-trusty-go_agent

--- a/47_spiff_merge_redis_to_bosh_lite/pipeline-bosh-deploy.yml
+++ b/47_spiff_merge_redis_to_bosh_lite/pipeline-bosh-deploy.yml
@@ -78,7 +78,7 @@ resources:
 - name: resource-bosh-deployment
   type: bosh-deployment
   source:
-    target: {{bosh-target}}
+    target: {{bosh-director}}
     username: {{bosh-username}}
     password: {{bosh-password}}
     deployment: {{section-47-git-redis-name}} # from the manifest.yml in resource-manifest

--- a/47_spiff_merge_redis_to_bosh_lite/run.sh
+++ b/47_spiff_merge_redis_to_bosh_lite/run.sh
@@ -20,17 +20,24 @@ usage() {
   exit 1
 }
 
-if [[ "${stub}X" == "X" ]]; then
-  usage
+
+if [ -z "${stub}" ]; then
+  stub="../credentials.yml"
 fi
-stub=$(realpath $stub)
 if [[ ! -f ${stub} ]]; then
   usage
 fi
+stub=$(realpath $stub)
 
-if [[ "${stage}" != "build-task-image" && "${stage}" != "bosh-deploy" ]]; then
+if [ -z "${stage}" ]; then
+  ./run.sh ${stub} build-task-image
+  ./run.sh ${stub} bosh-deploy
+  exit 0
+elif [[ "${stage}" != "build-task-image" && "${stage}" != "bosh-deploy" ]]; then
   usage
 fi
+
+echo "Stage: ${stage}"
 
 
 pushd $DIR

--- a/51_dummy_resource_docker_image/run.sh
+++ b/51_dummy_resource_docker_image/run.sh
@@ -14,15 +14,20 @@ realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-if [[ -z ${stub} ]]; then
+usage() {
   echo "USAGE: run.sh path/to/credentials.yml"
   exit 1
+}
+
+
+if [ -z "${stub}" ]; then
+  stub="../credentials.yml"
 fi
 stub=$(realpath $stub)
-if [[ ! -f ${stub} ]]; then
-  echo "USAGE: run.sh path/to/credentials.yml"
-  exit 1
+if [ ! -f ${stub} ]; then
+  usage
 fi
+
 
 pushd $DIR
   fly sp -t ${fly_target} configure -c pipeline.yml -p main --load-vars-from ${stub} -n

--- a/70_pivnet_updates/run.sh
+++ b/70_pivnet_updates/run.sh
@@ -14,14 +14,17 @@ realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-if [[ -z ${stub} ]]; then
-  echo "USAGE: run.sh path/to/credentials.yml"
+usage() {
+  echo "USAGE: run.sh credentials.yml [build-task-image|bosh-deploy]"
   exit 1
+}
+
+if [ -z "${stub}" ]; then
+  stub="../credentials.yml"
 fi
 stub=$(realpath $stub)
 if [[ ! -f ${stub} ]]; then
-  echo "USAGE: run.sh path/to/credentials.yml"
-  exit 1
+  usage
 fi
 
 pushd $DIR

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,7 +1,15 @@
 # Tutorial's own CI pipeline
 
+This is the pipeline which checks that the tutorial is working.
+
+
+## Setup
+
+To run this pipline you'll need to give it access to a BOSH
+director and a Cloud Foundry account.
+
 
 ```
-fly -t oss set-pipeline -p $(basename $(pwd)) -c ci/pipeline.yml -l ci/credentials.yml
-fly -t oss unpause-pipeline -p $(basename $(pwd))
+fly -t ${fly_target} set-pipeline -p concourse-tutorial -c ci/pipeline.yml -l ci/credentials.yml -l credentials.yml
+fly -t ${fly_target} unpause-pipeline -p concourse-tutorial
 ```

--- a/ci/bin/bosh-login
+++ b/ci/bin/bosh-login
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+pwd
+source ci/lib/pretty-output.sh
+source ci/lib/shared-functions.sh
+
+announce-started
+ensure-rvm
+bosh-login

--- a/ci/bin/create-credentials-yml
+++ b/ci/bin/create-credentials-yml
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+source ci/lib/pretty-output.sh
+source ci/lib/shared-functions.sh
+
+announce-started
+ensure-rvm
+
+run-cmd rvm-exec 2.2.4 ci/bin/create-credentials-yml.rb
+
+announce-success

--- a/ci/bin/create-credentials-yml.rb
+++ b/ci/bin/create-credentials-yml.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+require 'colorize'
+
+OUTFILE = "../credentials/credentials.yml"
+
+puts "Boo."
+
+
+def fail_exit(msg)
+  STDERR.puts "ERROR: ".bold.red + msg.red
+  exit(-1)
+end
+
+credential_names = %w(gist-url
+  github-private-key
+  docker-hub-username
+  docker-hub-password
+  docker-hub-email
+  docker-hub-image-hello-world
+  cf-api
+  cf-username
+  cf-password
+  cf-organization
+  cf-space
+  git-uri-bump-semver
+  bosh-director
+  bosh-username
+  bosh-password
+  bosh-stemcell-name
+  docker-hub-image-47-tasks
+  docker-hub-image-47-tasks-repository
+  section-47-git-redis-manifest
+  section-47-git-redis-name
+  docker-hub-image-dummy-resource
+  pivnet-api-token
+  aws-access-key-id
+  aws-secret-access-key
+  aws-region-name
+  aws-bosh-init-bucket)
+
+credentials = {}
+
+credential_names.each do |cn|
+  env_var_name = cn.gsub(/-/, '_')
+  credentials[cn] = ENV[env_var_name]
+end
+
+if (File.exist? OUTFILE)
+  fail_exit "%{OUTFILE} already exists. Exiting."
+end
+
+File.open(OUTFILE, 'w') do |file|
+  file.write( credentials.to_yaml )
+end

--- a/ci/bin/deploy-concourse
+++ b/ci/bin/deploy-concourse
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+
+source ci/lib/pretty-output.sh
+source ci/lib/shared-functions.sh
+
+announce-started
+ensure-rvm
+ensure-fly
+bosh-login
+deploy-concourse
+check-concourse
+
+announce-success

--- a/ci/bin/run-all-lessons
+++ b/ci/bin/run-all-lessons
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+source ci/lib/pretty-output.sh
+source ci/lib/shared-functions.sh
+
+export fly_target=${fly_target:-tutorial}
+
+announce-started
+ensure-rvm
+ensure-fly
+ensure-bosh-cli
+bosh-login
+check-concourse
+ensure-credentials-yml
+
+announce-task "Running all lessons"
+for f in */run.sh
+do
+  run-cmd pushd `dirname $f`
+  run-cmd ./run.sh
+  run-cmd popd
+done
+
+announce-success

--- a/ci/ci_image/Dockerfile
+++ b/ci/ci_image/Dockerfile
@@ -1,30 +1,17 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.10
 
-RUN apt-get update && apt-get install git zip unzip curl wget vagrant file zlib1g-dev libxml2 -y && \
-    apt-get clean
+RUN apt-get update && \
+  apt-get install -y git zip unzip curl wget zlib1g-dev libxml2 dirmngr && \
+  apt-get clean && \
+  gpg --keyserver hkp://keys.gnupg.net \
+  --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 && \
+  \curl -sSL https://get.rvm.io | bash -s stable
 
-# RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 && \
-#    \curl -sSL https://get.rvm.io | bash -s stable
-# ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-# RUN /bin/bash -l -c "rvm install 2.2"
-# RUN /bin/bash -l -c "rvm use 2.2 --default"
-# RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
+ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+COPY gemrc /root/.gemrc
+RUN /bin/bash -l -c "rvm install 2.2.4 && \
+  rvm use 2.2.4 --default && \
+  rvm 2.2.4 do gem install bosh_cli colorize"
 
-RUN ruby --version
-RUN gem install nokogiri -v '1.6.8' --no-ri --no-rdoc
-RUN vagrant plugin install vagrant-aws
-
-ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/bin/jq
-RUN chmod 775 /usr/bin/jq
-
-# Install Go & yaml2json
-RUN \
-  mkdir -p /goroot && \
-  curl https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
-
-# Set environment variables.
-ENV GOROOT /goroot
-ENV GOPATH /gopath
-ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
-
-RUN go get github.com/bronze1man/yaml2json
+ADD https://github.com/concourse/concourse/releases/download/v2.6.0/fly_linux_amd64 /usr/local/bin/fly
+RUN chmod 755 /usr/local/bin/fly

--- a/ci/ci_image/gemrc
+++ b/ci/ci_image/gemrc
@@ -1,0 +1,1 @@
+gem: --no-document

--- a/ci/lib/pretty-output.sh
+++ b/ci/lib/pretty-output.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Functions for pretty output
+#
+
+
+export CF_COLOR=true
+RCol='\033[0m'
+BCya='\033[1;36m'
+BGre='\033[1;32m'
+BRed='\033[1;31m'
+BWhi='\033[1;37m'
+BYel='\033[1;33m'
+Cya='\033[0;36m'
+Gre='\033[0;32m'
+Red='\033[0;31m'
+Yel='\033[0;33m'
+
+function announce-started {
+  echo -e "\n\n${BCya}---"
+  echo -e "${BCya}${0} started."
+  echo -e "${BCya}---${RCol}"
+  echo
+  echo
+}
+
+function announce-task {
+  echo -e "\n\n${BWhi}---"
+  echo -e "${BWhi}${1}"
+  echo -e "${BWhi}---${RCol}"
+}
+
+function announce-success {
+  echo -e "${BGre}Mission accomplished.${RCol}"
+}
+
+function run-cmd {
+  echo -e "\n\n${Cya}${@}${RCol}\n"
+  $@
+}
+
+function fail-error {
+  echo -e "\n\n${BRed}ERROR: ${Red}${@} ${BRed}Exiting.\n${RCol}"
+  exit -1
+}

--- a/ci/lib/shared-functions.sh
+++ b/ci/lib/shared-functions.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+export fly_target=${fly_target:-tutorial}
+
+function ensure-rvm {
+  announce-task "Making sure RVM is set up..."
+  set +ux
+  if [ -s "$HOME/.rvm/scripts/rvm" ] ; then
+    run-cmd source "$HOME/.rvm/scripts/rvm"
+  elif [ -s "/usr/local/rvm/scripts/rvm" ] ; then
+    run-cmd source "/usr/local/rvm/scripts/rvm"
+  else
+    fail-error "An RVM installation was not found."
+  fi
+  set -u
+}
+
+function ensure-fly {
+  announce-task "Making sure fly is installed..."
+
+  if [ `which fly` ]; then
+    echo "Fly is at `which fly`"
+  else
+    echo "Fly not found. Installing..."
+    run-cmd curl -L https://github.com/concourse/concourse/releases/download/v2.5.0/fly_linux_amd64 -o /usr/local/bin/fly
+    run-cmd chmod 755 /usr/local/bin/fly
+    run-cmd fly -t ${fly_target} sync
+
+  fi
+}
+
+function ensure-bosh-cli {
+  announce-task "Making sure BOSH CLI is installed..."
+
+  if [ `which bosh` ]; then
+    echo "BOSH CLI is at `which bosh`"
+  else
+    fail-error "BOSH CLI not found in path."
+  fi
+}
+
+function ensure-credentials-yml {
+  announce-task "Ensuring we have a credentials.yml..."
+
+  if [ -e "credentials.yml" ]; then
+    echo "Found credentials.yml in repo root."
+  elif [ -e "../credentials/credentials.yml" ]; then
+    echo "Found ../credentials/credentials.yml. Linking..."
+    ln -s "../credentials/credentials.yml"
+  else
+    fail-error "Could not find credentials.yml."
+  fi
+}
+
+function bosh-login {
+  announce-task "Logging-in to BOSH director..."
+  which bosh
+  bosh version
+
+  set +x
+  bosh -t ${bosh_director} login ${bosh_username} ${bosh_password}
+  run-cmd bosh target ${bosh_director}
+  run-cmd bosh status
+}
+
+function deploy-concourse {
+  announce-task "Starting deployment..."
+  run-cmd bosh deployment ci/manifest-vsphere-4.yml
+  run-cmd bosh -n deploy
+  run-cmd bosh instances
+}
+
+function check-concourse {
+  announce-task "Making sure Concourse is up..."
+  run-cmd fly login -t ${fly_target} -c http://10.58.111.191
+  run-cmd fly -t ${fly_target} sync
+  run-cmd fly -t ${fly_target} pipelines
+}

--- a/ci/manifest-vsphere-4.yml
+++ b/ci/manifest-vsphere-4.yml
@@ -1,0 +1,167 @@
+---
+name: concourse-tutorial-ci
+
+director_uuid: f635b1ba-5000-48e1-92c8-19471d20e0e4
+
+compilation:
+  cloud_properties:
+    cpu: 2
+    disk: 8096
+    ram: 3840
+  network: concourse
+  reuse_compilation_vms: true
+  workers: 2
+disk_pools: []
+
+jobs:
+
+- name: haproxy
+  instances: 1
+  networks:
+  - name: concourse
+    static_ips:
+    - 10.58.111.191
+  resource_pool: medium_vm
+  templates:
+  - name: haproxy
+    release: cf-haproxy
+    properties:
+      ha_proxy:
+        backend_port: 8080
+        backend_servers:
+        - 10.58.111.192
+
+- name: web
+  instances: 1
+  networks:
+  - name: concourse
+    static_ips:
+    - 10.58.111.192
+  resource_pool: medium_vm
+  templates:
+  - name: tsa
+    release: concourse
+    properties: {}
+  - name: atc
+    release: concourse
+    properties:
+      external_url: http://10.58.111.191
+      postgresql_database: atc
+      development_mode: true
+
+- name: db
+  instances: 1
+  networks:
+  - name: concourse
+    static_ips:
+    - 10.58.111.193
+  persistent_disk: 10240
+  resource_pool: medium_vm
+  templates:
+  - name: postgresql
+    properties:
+      databases:
+      - name: atc
+        password: dummy-postgres-password
+        role: atc
+    release: concourse
+
+- name: worker
+  instances: 1
+  networks:
+  - name: concourse
+    static_ips:
+    - 10.58.111.194
+    # - 10.58.111.195
+    # - 10.58.111.196
+
+  resource_pool: large_vm
+  templates:
+  - name: groundcrew
+    release: concourse
+    properties: {}
+  - name: baggageclaim
+    release: concourse
+    properties: {}
+  - name: garden
+    release: garden-runc
+    properties:
+      garden:
+        enable_graph_cleanup: true
+        listen_address: 0.0.0.0:7777
+        listen_network: tcp
+
+networks:
+- name: concourse
+  subnets:
+  - cloud_properties:
+      name: net-10-58-111-0
+    dns:
+    - 10.58.111.31
+    - 10.58.111.32
+    - 10.58.111.33
+    gateway: 10.58.111.1
+    range: 10.58.111.0/24
+    reserved:
+    - 10.58.111.2 - 10.58.111.190
+    - 10.58.111.199 - 10.58.111.254
+    static:
+    - 10.58.111.191 - 10.58.111.194
+releases:
+- name: cf-haproxy
+  version: 6
+- name: concourse
+  version: 2.6.0
+- name: garden-runc
+  version: 1.0.4
+resource_pools:
+- cloud_properties:
+    cpu: 1
+    disk: 4096
+    ram: 2048
+  name: small_vm
+  network: concourse
+  stemcell:
+    name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
+    sha1: 4d26fc17fdb30455741e155ba77bdcbe2f6130d9
+    url: https://s3.amazonaws.com/bosh-core-stemcells/vsphere/bosh-stemcell-3312.8-vsphere-esxi-ubuntu-trusty-go_agent.tgz
+    version: 3312.8
+- cloud_properties:
+    cpu: 2
+    disk: 4096
+    ram: 3840
+  name: medium_vm
+  network: concourse
+  stemcell:
+    name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
+    sha1: 4d26fc17fdb30455741e155ba77bdcbe2f6130d9
+    url: https://s3.amazonaws.com/bosh-core-stemcells/vsphere/bosh-stemcell-3312.8-vsphere-esxi-ubuntu-trusty-go_agent.tgz
+    version: 3312.8
+- cloud_properties:
+    cpu: 2
+    disk: 70000
+    ram: 7680
+  name: large_vm
+  network: concourse
+  stemcell:
+    name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
+    sha1: 4d26fc17fdb30455741e155ba77bdcbe2f6130d9
+    url: https://s3.amazonaws.com/bosh-core-stemcells/vsphere/bosh-stemcell-3312.8-vsphere-esxi-ubuntu-trusty-go_agent.tgz
+    version: 3312.8
+- cloud_properties:
+    cpu: 2
+    disk: 512000
+    ram: 7680
+  name: large_storage_vm
+  network: concourse
+  stemcell:
+    name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
+    sha1: 4d26fc17fdb30455741e155ba77bdcbe2f6130d9
+    url: https://s3.amazonaws.com/bosh-core-stemcells/vsphere/bosh-stemcell-3312.8-vsphere-esxi-ubuntu-trusty-go_agent.tgz
+    version: 3312.8
+update:
+  canaries: 10
+  canary_watch_time: 1000-60000
+  max_in_flight: 5
+  serial: false
+  update_watch_time: 1000-60000

--- a/ci/manifest.example.yml
+++ b/ci/manifest.example.yml
@@ -1,0 +1,99 @@
+---
+name: concourse-tutorial-concourse
+
+# replace with `bosh status --uuid`
+director_uuid: REPLACE_ME
+
+releases:
+- name: concourse
+  version: latest
+- name: garden-runc
+  version: latest
+
+stemcells:
+- alias: trusty
+  os: ubuntu-trusty
+  version: latest
+
+instance_groups:
+- name: web
+  instances: 1
+  # replace with a VM type from your BOSH Director's cloud config
+  vm_type: REPLACE_ME
+  vm_extensions:
+  # replace with a VM extension from your BOSH Director's cloud config that will attach
+  # this instance group to your ELB
+  - REPLACE_ME
+  stemcell: trusty
+  azs: [z1]
+  networks: [{name: private}]
+  jobs:
+  - name: atc
+    release: concourse
+    properties:
+      # replace with your CI's externally reachable URL, e.g. https://ci.foo.com
+      external_url: REPLACE_ME
+
+      # replace with username/password, or configure GitHub auth
+      basic_auth_username: REPLACE_ME
+      basic_auth_password: REPLACE_ME
+
+      # replace with your SSL cert and key
+      tls_cert: REPLACE_ME
+      tls_key: REPLACE_ME
+
+      postgresql_database: &atc_db atc
+  - name: tsa
+    release: concourse
+    properties: {}
+
+- name: db
+  instances: 1
+  # replace with a VM type from your BOSH Director's cloud config
+  vm_type: REPLACE_ME
+  stemcell: trusty
+  # replace with a disk type from your BOSH Director's cloud config
+  persistent_disk_type: REPLACE_ME
+  azs: [z1]
+  networks: [{name: private}]
+  jobs:
+  - name: postgresql
+    release: concourse
+    properties:
+      databases:
+      - name: *atc_db
+        # make up a role and password
+        role: REPLACE_ME
+        password: REPLACE_ME
+
+- name: worker
+  instances: 1
+  # replace with a VM type from your BOSH Director's cloud config
+  vm_type: REPLACE_ME
+  vm_extensions:
+  # replace with a VM extension from your BOSH Director's cloud config that will attach
+  # sufficient ephemeral storage to VMs in this instance group.
+  - REPLACE_ME
+  stemcell: trusty
+  azs: [z1]
+  networks: [{name: private}]
+  jobs:
+  - name: groundcrew
+    release: concourse
+    properties: {}
+  - name: baggageclaim
+    release: concourse
+    properties: {}
+  - name: garden
+    release: garden-runc
+    properties:
+      garden:
+        listen_network: tcp
+        listen_address: 0.0.0.0:7777
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  serial: false
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000

--- a/ci/manifest.yml
+++ b/ci/manifest.yml
@@ -1,0 +1,109 @@
+---
+name: concourse-tutorial
+
+director_uuid: 0da328bf-081f-4235-b7f8-a0d0592d258d
+
+releases:
+  - name: concourse
+    version: 2.5.0
+  - name: garden-linux
+    version: 0.342.0
+  - name: cf-haproxy
+    version: 8.0.5
+
+instance_groups:
+  - name: haproxy
+    instances: 1
+    resource_pool: concourse
+    networks:
+      - name: concourse
+        static_ips: [10.244.8.3]
+    templates:
+      - release: cf-haproxy
+        name: haproxy
+    properties:
+      ha_proxy:
+        backend_port: 8080
+        backend_servers: [10.244.8.2]
+
+  - name: web
+    instances: 1
+    resource_pool: concourse
+    networks:
+      - name: concourse
+        static_ips: [10.244.8.2]
+    jobs:
+      - release: concourse
+        name: atc
+        properties:
+          postgresql_database: &atc-db atc
+          external_url: http://10.244.8.2:8080
+          development_mode: true
+      - release: concourse
+        name: tsa
+        properties: {}
+
+  - name: db
+    instances: 1
+    resource_pool: concourse
+    networks: [{name: concourse}]
+    persistent_disk: 10240
+    jobs:
+      - release: concourse
+        name: postgresql
+        properties:
+          databases:
+          - name: *atc-db
+            role: atc
+            password: dummy-postgres-password
+
+  - name: worker
+    instances: 1
+    resource_pool: concourse
+    networks: [{name: concourse}]
+    jobs:
+      - release: concourse
+        name: groundcrew
+        properties: {}
+      - release: concourse
+        name: baggageclaim
+        properties: {}
+      - release: garden-linux
+        name: garden
+        properties:
+          garden:
+            # cannot enforce quotas in bosh-lite
+            disk_quota_enabled: false
+
+            listen_network: tcp
+            listen_address: 0.0.0.0:7777
+
+            allow_host_access: true
+
+networks:
+  - name: concourse
+    type: manual
+    subnets:
+    - range: 10.244.8.0/24
+      gateway: 10.244.8.1
+      static: [10.244.8.2, 10.244.8.3]
+
+resource_pools:
+  - name: concourse
+    network: concourse
+    cloud_properties: {}
+    stemcell:
+      name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+      version: latest
+
+compilation:
+  workers: 3
+  network: concourse
+  cloud_properties: {}
+
+update:
+  canaries: 1
+  max_in_flight: 3
+  serial: false
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,31 +1,116 @@
 ---
-groups:
-- name: image
-  jobs:
-  - build-task-image
-
 jobs:
 - name: build-task-image
   serial: true
   plan:
   - get: repo-image
     trigger: true
-  - put: ciimage
+  - put: ci-image
     params:
       build: repo-image/ci/ci_image
+
+- name: deploy-concourse
+  serial: true
+  plan:
+  - aggregate:
+    - get: repo
+      trigger: true
+    - get: ci-image
+      passed: [build-task-image]
+      trigger: true
+  - task: deploy-concourse
+    image: ci-image
+    config:
+      platform: linux
+      inputs:
+        - { name: repo }
+      run:
+        dir: repo
+        path: ci/bin/deploy-concourse
+    params:
+      bosh_director: {{ci-bosh-director}}
+      bosh_username: {{ci-bosh-username}}
+      bosh_password: {{ci-bosh-password}}
+
+- name: run-all-lessons
+  plan:
+  - aggregate:
+    - get: repo
+      passed: [deploy-concourse]
+      trigger: true
+    - get: ci-image
+      passed: [deploy-concourse]
+      trigger: false
+  - task: create-credentials-yml
+    image: ci-image
+    config:
+      platform: linux
+      inputs:
+        - { name: repo }
+      outputs:
+        - { name: credentials }
+      run:
+        dir: repo
+        path: ci/bin/create-credentials-yml
+    params:
+      bosh_director: {{ci-bosh-director}}
+      bosh_username: {{ci-bosh-username}}
+      bosh_password: {{ci-bosh-password}}
+      gist_url: {{gist-url}}
+      github_private_key: {{github-private-key}}
+      docker_hub_username: {{docker-hub-username}}
+      docker_hub_password: {{docker-hub-password}}
+      docker_hub_email: {{docker-hub-email}}
+      docker_hub_image_hello_world: {{docker-hub-image-hello-world}}
+      cf_api: {{cf-api}}
+      cf_username: {{cf-username}}
+      cf_password: {{cf-password}}
+      cf_organization: {{cf-organization}}
+      cf_space: {{cf-space}}
+      git_uri_bump_semver: {{git-uri-bump-semver}}
+      bosh_director: {{bosh-director}}
+      bosh_username: {{bosh-username}}
+      bosh_password: {{bosh-password}}
+      bosh_stemcell_name: {{bosh-stemcell-name}}
+      docker_hub_image_47_tasks: {{docker-hub-image-47-tasks}}
+      docker_hub_image_47_tasks_repository: {{docker-hub-image-47-tasks-repository}}
+      section_47_git_redis_manifest: {{section-47-git-redis-manifest}}
+      section_47_git_redis_name: {{section-47-git-redis-name}}
+      docker_hub_image_dummy_resource: {{docker-hub-image-dummy-resource}}
+      pivnet_api_token: {{pivnet-api-token}}
+      aws_access_key_id: {{aws-access-key-id}}
+      aws_secret_access_key: {{aws-secret-access-key}}
+      aws_region_name: {{aws-region-name}}
+      aws_bosh_init_bucket: {{aws-bosh-init-bucket}}
+  - task: run-all-lessons
+    image: ci-image
+    config:
+      platform: linux
+      inputs:
+        - { name: repo }
+        - { name: credentials }
+      run:
+        dir: repo
+        path: ci/bin/run-all-lessons
+    params:
+      bosh_director: {{ci-bosh-director}}
+      bosh_username: {{ci-bosh-username}}
+      bosh_password: {{ci-bosh-password}}
 
 resources:
 - name: repo
   type: git
   source:
     uri: https://github.com/starkandwayne/concourse-tutorial.git
+    branch: set-up-ci
+    ignore_paths: [ci/ci_image/*]
 - name: repo-image
   type: git
   source:
     uri: https://github.com/starkandwayne/concourse-tutorial.git
     branch: set-up-ci
     paths: [ci/ci_image/*]
-- name: ciimage
+- name: ci-image
   type: docker-image
   source:
     email: {{docker-hub-email}}


### PR DESCRIPTION
CI for the tutorial itself so that, among other things, we don't have to manually test everything each time there is a new release of Concourse.

There's more work to be done:

- `run.sh` for the first back of lessons is still a no-op
- Lots of duplication and inconsistency in run scripts
- Versions of a few tools need updating
- Concourse deployment could be simplified to use fewer VMs

