### PR TITLE
Concourse 2.7.0 Change in Job output of step 04 - Basic pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ jobs:
           path: echo
           args:
           - hello world
+          dir: ""
 ```
 
 You will be prompted to apply any configuration changes each time you run `fly set-pipeline` (or its alias `fly sp`)


### PR DESCRIPTION
Fly version `2.7.0`
When running `04 - Basic pipeline step`
```
fly --target tutorial set-pipeline --config pipeline.yml --pipeline helloworld 
```

the output now shows `dir: ""`  , a new attribute.

```

jobs:
  job job-hello-world has been added:
    name: job-hello-world
    public: true
    plan:
    - task: hello-world
      config:
        platform: linux
        image_resource:
          type: docker-image
          source:
            repository: busybox
        run:
          path: echo
          args:
          - hello world
          dir: ""
```