### PR TITLE
Relative links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,26 @@ Learn to use https://concourse.ci with this linear sequence of tutorials. Learn 
 
 ## Sections
 
-* [01 - Hello World task](https://github.com/starkandwayne/concourse-tutorial#01---hello-world-task)
-* [02 - Task inputs](https://github.com/starkandwayne/concourse-tutorial#02---task-inputs)
-* [03 - Task scripts](https://github.com/starkandwayne/concourse-tutorial#03---task-scripts)
-* [04 - Basic pipeline](https://github.com/starkandwayne/concourse-tutorial#04---basic-pipeline)
-* [05 - Tasks extracted into Resources](https://github.com/starkandwayne/concourse-tutorial#05---tasks-extracted-into-resources)
-* [06 - View job output in terminal](https://github.com/starkandwayne/concourse-tutorial#06---view-job-output-in-terminal)
-* [07 - Trigger jobs with fly](https://github.com/starkandwayne/concourse-tutorial#07---trigger-jobs-with-fly)
-* [08 - Triggering jobs with resources](https://github.com/starkandwayne/concourse-tutorial#08---triggering-jobs-with-resources)
-* [09 - Destroying pipelines](https://github.com/starkandwayne/concourse-tutorial#09---destroying-pipelines)
-* [10 - Using resource inputs in job tasks](https://github.com/starkandwayne/concourse-tutorial#10---using-resource-inputs-in-job-tasks)
-* [11 - Passing task outputs to another task](https://github.com/starkandwayne/concourse-tutorial#11---passing-task-outputs-to-another-task)
-* [12 - Publishing outputs](https://github.com/starkandwayne/concourse-tutorial#12---publishing-outputs)
-* [13 - Actual pipeline - passing resources between jobs](https://github.com/starkandwayne/concourse-tutorial#13---actual-pipeline---passing-resources-between-jobs)
-* [14 - Parameterized pipelines](https://github.com/starkandwayne/concourse-tutorial#14---parameterized-pipelines)
+* [01 - Hello World task](#01---hello-world-task)
+* [02 - Task inputs](#02---task-inputs)
+* [03 - Task scripts](#03---task-scripts)
+* [04 - Basic pipeline](#04---basic-pipeline)
+* [05 - Tasks extracted into Resources](#05---tasks-extracted-into-resources)
+* [06 - View job output in terminal](#06---view-job-output-in-terminal)
+* [07 - Trigger jobs with fly](#07---trigger-jobs-with-fly)
+* [08 - Triggering jobs with resources](#08---triggering-jobs-with-resources)
+* [09 - Destroying pipelines](#09---destroying-pipelines)
+* [10 - Using resource inputs in job tasks](#10---using-resource-inputs-in-job-tasks)
+* [11 - Passing task outputs to another task](#11---passing-task-outputs-to-another-task)
+* [12 - Publishing outputs](#12---publishing-outputs)
+* [13 - Actual pipeline - passing resources between jobs](#13---actual-pipeline---passing-resources-between-jobs)
+* [14 - Parameterized pipelines](#14---parameterized-pipelines)
 
 The following sections are found in subfolders of this repository and the tutorial continues in their README:
 
-* [15 - Deploy application to Cloud](https://github.com/starkandwayne/concourse-tutorial/tree/master/15_deploy_cloudfoundry_app)
-* [16 - Run tests, then deploy application](https://github.com/starkandwayne/concourse-tutorial/tree/master/16_run_tests_before_deploy)
-* [20 - Versions and build numbers](https://github.com/starkandwayne/concourse-tutorial/tree/master/20_versions_and_buildnumbers)
+* [15 - Deploy application to Cloud](15_deploy_cloudfoundry_app/README.md)
+* [16 - Run tests, then deploy application](16_run_tests_before_deploy/README.md)
+* [20 - Versions and build numbers](20_versions_and_buildnumbers/README.md)
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ succeeded
 
 The reason that you can select any base `image` (or `image_resource` when [configuring a task](http://concourse.ci/running-tasks.html)) is that this allows your task to have any prepared dependencies that it needs to run. Instead of installing dependencies each time during a task you might choose to pre-bake them into an `image` to make your tasks much faster.
 
+[Go to Top](#concourse-tutorial)
+
 ### 02 - Task inputs
 
 In the previous section the only inputs to the task container were the `image` used. Base images, such as Docker images, are relatively static and relatively big, slow things to create. So Concourse supports `inputs` into tasks to pass in files/folders for processing.
@@ -254,6 +256,8 @@ The task `input_parent_dir.yml` contains an input `02_task_inputs` which is also
 fly --target tutorial execute --config input_parent_dir.yml
 ```
 
+[Go to Top](#concourse-tutorial)
+
 ### 03 - Task scripts
 
 The `inputs` feature of a task allows us to pass in two types of inputs:
@@ -293,6 +297,8 @@ The current directory was uploaded to the Concourse task container and placed in
 Therefore its file `task_show_uname.sh` is available within the Concourse task container at `03_task_scripts/task_show_uname.sh`.
 
 The only further requirement is that `task_show_uname.sh` is an executable script.
+
+[Go to Top](#concourse-tutorial)
 
 ### 04 - Basic pipeline
 
@@ -358,6 +364,8 @@ Click on `job-hello-world` and then click on the large `+` in the top right corn
 ![job](http://cl.ly/image/3i2e0k0v3O2l/02-job-hello-world.gif)
 
 Clicking the top-left "Home" icon will show the status of our pipeline. The job `job-hello-world` is now green. This means that the last time the job ran it completed successfully.
+
+[Go to Top](#concourse-tutorial)
 
 ### 05 - Tasks extracted into Resources
 
@@ -471,6 +479,8 @@ From now onwards, any change to your pipeline might require you to do one or bot
 
 If the new behavior you intended is not showing up in the pipeline then you may have skipped one of the two steps above.
 
+[Go to Top](#concourse-tutorial)
+
 ### 06 - View job output in terminal
 
 The `job-hello-world` had terminal output from its resource fetch of a git repo and of the `hello-world` task running.
@@ -515,6 +525,8 @@ id  pipeline/job                build  status     start                     end 
 1   one-off                     n/a    succeeded  2017-01-09@10:39:41-0800  2017-01-09@10:39:51-0800  10s
 ```
 
+[Go to Top](#concourse-tutorial)
+
 ### 07 - Trigger jobs with `fly`
 
 There are three ways for a job to be triggered:
@@ -533,6 +545,8 @@ Whilst the job is running, and after it has completed, you can then watch the ou
 ```
 fly --target tutorial watch --job helloworld/job-hello-world
 ```
+
+[Go to Top](#concourse-tutorial)
 
 ### 08 - Triggering jobs with resources
 
@@ -589,6 +603,8 @@ Why does `time` resource configured with `interval: 2m` trigger "approximately" 
 
 The net result is that a timer of `2m` will trigger every 2 to 3 minutes.
 
+[Go to Top](#concourse-tutorial)
+
 ### 09 - Destroying pipelines
 
 The current `helloworld` pipeline will now keep triggering every 2-3 minutes for ever. If you want to destroy a pipeline - and lose all its build history - then may the power be granted to you.
@@ -598,6 +614,8 @@ You can delete the `helloworld` pipeline:
 ```
 fly destroy-pipeline --target tutorial --pipeline helloworld
 ```
+
+[Go to Top](#concourse-tutorial)
 
 ### 10 - Using resource inputs in job tasks
 
@@ -646,6 +664,7 @@ The `web-app-tests` output below corresponds to the Go language test output (in 
 ok  	github.com/cloudfoundry-community/simple-go-web-app	0.003s
 ```
 
+[Go to Top](#concourse-tutorial)
 
 ### 11 - Passing task outputs to another task
 
@@ -702,6 +721,7 @@ mkdir: can't create directory 'some-files': File exists
 
 This is a demonstration that if a task includes `outputs` then those output directories are pre-created and do not need creating.
 
+[Go to Top](#concourse-tutorial)
 
 ### 12 - Publishing outputs
 
@@ -797,6 +817,8 @@ The `updated-gist` output from the `bump-timestamp-file` task becomes the `updat
 
 The `bump-timestamp-file.sh` script needed the `git` CLI tool. It could have installed it each time via `apt-get install git` or similar, but this would have made the task very slow. Instead `bump-timestamp-file.yml` task file uses a different base image `concourse/concourse-ci` that contains `git` CLI (and many other pre-installed packages). The contents of this Docker image are described at https://github.com/concourse/concourse/blob/master/ci/dockerfiles/bosh-cli/Dockerfile
 
+[Go to Top](#concourse-tutorial)
+
 ### 13 - Actual pipeline - passing resources between jobs
 
 Finally, it is time to make an actual pipeline - one job passing results to another job upon success.
@@ -840,6 +862,8 @@ The latest `resource-gist` commit fetched down in `job-show-date` will be the ex
 
 ![trigger](http://cl.ly/3x1t0T450g1h/download/pipeline-flow.gif)
 
+[Go to Top](#concourse-tutorial)
+
 ### 14 - Parameterized pipelines
 
 In the preceding sections you were asked to private credentials and personal git URLs into the `pipeline.yml` files. This would make it difficult to share your `pipeline.yml` with anyone who had access to the repository. Not everyone needs nor should have access to the shared secrets.
@@ -881,6 +905,8 @@ To pass in your `credentials.yml` file use the `--load-vars-from` or `-l` option
 ```
 fly set-pipeline --target tutorial --config pipeline.yml --pipeline publishing-outputs --non-interactive --load-vars-from ../credentials.yml
 ```
+
+[Go to Top](#concourse-tutorial)
 
 ## Continuing the tutorial
 
@@ -933,3 +959,5 @@ time
 tracker
 vagrant-cloud
 ```
+
+[Go to Top](#concourse-tutorial)


### PR DESCRIPTION
Simple changes:
* Used relative links as opposed to absolute links (as described in [github guide](https://help.github.com/articles/basic-writing-and-formatting-syntax/#relative-links)) - use the file in your favourite editor, without the need for a browser.
* Added `Go to Top` as way to make the navigation even easier - often times I had to go back check previous examples and it is really easy to go to the top and then click on the section.

These changes helped me while reading through the README file. Hope it makes sense.