### PR TITLE
11_task_outputs_to_inputs - avoid folder exist error message

### DIFF
--- a/11_task_outputs_to_inputs/create_some_files.sh
+++ b/11_task_outputs_to_inputs/create_some_files.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-mkdir some-files
+mkdir -p some-files
 echo "file1" > some-files/file1
 echo "file2" > some-files/file2
 echo "file3" > some-files/file3


### PR DESCRIPTION
- avoid folder exist error message

    mkdir: can't create directory 'some-files': File exists