### PR TITLE
Revert "configure syntax in line 33 unnecessary"

### DIFF
--- a/45_bosh_deploy/run.sh
+++ b/45_bosh_deploy/run.sh
@@ -30,7 +30,7 @@ if [[ ! -f ${stub} ]]; then
 fi
 
 pushd $DIR
-  fly sp -t ${fly_target} -c pipeline.yml -p main --load-vars-from ${stub} -n
+  fly sp -t ${fly_target} configure -c pipeline.yml -p main --load-vars-from ${stub} -n
   fly -t ${fly_target} unpause-pipeline --pipeline main
   fly -t ${fly_target} trigger-job -j main/job-deploy
   fly -t ${fly_target} watch -j main/job-deploy


### PR DESCRIPTION
Reverts starkandwayne/concourse-tutorial#111

Apparently it's there for backward compatibility: https://github.com/starkandwayne/concourse-tutorial/blob/master/docs/alex-suraci-cfsummit-2015.md#debuggable-builds

cc @Dewtah 