### PR TITLE
Add blurb about short-hand commands

### DIFF
--- a/docs/basics/task-inputs.md
+++ b/docs/basics/task-inputs.md
@@ -20,6 +20,8 @@ drwxr-xr-x    2 root     root          4096 Feb 27 07:23 .
 drwxr-xr-x    3 root     root          4096 Feb 27 07:23 ..
 ```
 
+Note that above we used the short-hand form of the execute command in this example, simply **e**, as the action. Many commands have shortened single character forms, for example **fly s** is an alias for **fly sync**.
+
 In the example task `inputs_required.yml` we add a single input:
 
 ```yaml


### PR DESCRIPTION
It was not immediately obvious in this section what command
was being run since it is easy to miss seeing the "e". Add a blurb
about this and about short-hand for commands so we avoid losing
the readers.