### PR TITLE
Avoid error message when directory exists

### DIFF
--- a/tutorials/basic/task-outputs-to-inputs/create_some_files.sh
+++ b/tutorials/basic/task-outputs-to-inputs/create_some_files.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-mkdir some-files
+mkdir -p some-files
 echo "file1" > some-files/file1
 echo "file2" > some-files/file2
 echo "file3" > some-files/file3


### PR DESCRIPTION
Avoids "mkdir: can't create directory 'some-files': File exists" message.