### PR TITLE
Incorrect Reference to Previous Pipeline

### DIFF
--- a/docs/basics/pipeline-resources.md
+++ b/docs/basics/pipeline-resources.md
@@ -46,7 +46,7 @@ To deploy this change:
 
 ```
 cd ../pipeline-resources
-fly sp -t tutorial -c pipeline.yml -p helloworld
+fly sp -t tutorial -c pipeline.yml -p hello-world
 ```
 
 The output will show the delta between the two pipelines and request confirmation. Type `y`. If successful, it will show:


### PR DESCRIPTION
The documentation states that the previous pipeline was called ```helloworld`` and that there will be a delta.  The previous pipeline is actually called ```hello-world```.  The means that the new pipeline will not update the existing one and there will be no delta.

To fix this issue change to ```hello-world```