### PR TITLE
User and pasword were not prompted [4.2]

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,13 +61,8 @@ In the spirit of declaring absolutely everything you do to get absolutely the sa
 
 First, alias it with a name `tutorial` (this name is used by all the tutorial task scripts).
 
-When prompted for local username/password use:
-
-* username: admin
-* password: admin
-
 ```plain
-fly --target tutorial login --concourse-url http://127.0.0.1:8080
+fly --target tutorial login --concourse-url http://127.0.0.1:8080 -u admin -p admin
 fly --target tutorial sync
 ```
 


### PR DESCRIPTION
The basic auth has to be explicit in the cli as -u for user and -p for password.