### PR TITLE
Remove 'mkdir' for dir already created by 'outputs' in "task-outputs-to-inputs" tutorial

### DIFF
--- a/tutorials/basic/task-outputs-to-inputs/create_some_files.sh
+++ b/tutorials/basic/task-outputs-to-inputs/create_some_files.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-mkdir some-files
 echo "file1" > some-files/file1
 echo "file2" > some-files/file2
 echo "file3" > some-files/file3


### PR DESCRIPTION
### Tutorial: `tutorials/task-outputs-to-inputs`
In the `basic/task-outputs-to-inputs` tutorial, the `create_some_files.sh` attempts to first create the output directory `some-files`.  However, since this directory is also the name of one of the `outputs`, it is already created implicitly.  This causes a (harmless) error to appear in the task output.

### Current
**`tutorials/task-outputs-to-inputs/pipeline.yml`**
```
  - task: create-some-files
    ...

      inputs:
      - name: resource-tutorial
      outputs:
      - name: some-files

      run:
        path: resource-tutorial/tutorials/basic/task-outputs-to-inputs/create_some_files.sh
```

**`create_some_files.sh`**
```
#!/bin/sh

mkdir some-files
echo "file1" > some-files/file1
echo "file2" > some-files/file2
echo "file3" > some-files/file3
echo "file4" > some-files/file4

ls some-files/*
```

**Output**
```
initializing
running resource-tutorial/tutorials/basic/task-outputs-to-inputs/create_some_files.sh
mkdir: can't create directory 'some-files': File exists
some-files/file1  some-files/file2  some-files/file3  some-files/file4
initializing
running resource-tutorial/tutorials/basic/task-outputs-to-inputs/show_files.sh
some-files/file1  some-files/file2  some-files/file3  some-files/file4
succeeded
```
### Fix
This fix removes the error
```
mkdir: can't create directory 'some-files': File exists
```
It also helps the reader see that `outputs` directories are created implicitly.