### PR TITLE
Documentation Improvements

### DIFF
--- a/docs/basics/basic-pipeline.md
+++ b/docs/basics/basic-pipeline.md
@@ -59,8 +59,6 @@ It is a private pipeline and currently you are not logged in to the Concourse We
 
 Click "Login" and you'll be redirected back to your pipeline.
 
-Why did you not have to enter any username/password? Excellent question, indeed. It's because your current `fly -t tutorial` deployment of Concourse has had authentication disabled. In a future lesson we will upgrade to a more robust installation of Concourse with passwords and fanciness.
-
 ## Unpausing Pipelines
 
 Your pipeline has a blue bar across the top. This means it is paused. New pipelines start paused as you might not yet be ready for triggers to fire and start jobs running.

--- a/docs/basics/parameters.md
+++ b/docs/basics/parameters.md
@@ -105,7 +105,7 @@ resources:
 Create a `credentials.yml` with the Gist URL and private key:
 
 ```yaml
-publishing-outputs-gist-uri: "git@gist.github.com:e028e491e42b9fb08447a3bafcf884e5.git"
+publishing-outputs-gist-uri: git@gist.github.com:e028e491e42b9fb08447a3bafcf884e5.git
 publishing-outputs-private-key: |-
     -----BEGIN RSA PRIVATE KEY-----
     MIIEpQIBAAKCAQEAuvUl9YU...
@@ -118,6 +118,8 @@ Use the `--load-vars-from` or `-l` flag to pass the variables into the parameter
 
 ```
 fly -t tutorial sp -p publishing-outputs -c pipeline-parameters.yml -l credentials.yml
+fly -t tutorial up -p publishing-outputs
+fly -t tutorial trigger-job -j publishing-outputs/job-bump-date
 ```
 
 ## Dynamic Parameters and Secret Parameters

--- a/docs/basics/pipeline-resources.md
+++ b/docs/basics/pipeline-resources.md
@@ -46,7 +46,8 @@ To deploy this change:
 
 ```
 cd ../pipeline-resources
-fly sp -t tutorial -c pipeline.yml -p hello-world
+fly -t tutorial sp -c pipeline.yml -p hello-world
+fly -t tutorial up -p hello-world
 ```
 
 The output will show the delta between the two pipelines and request confirmation. Type `y`. If successful, it will show:

--- a/docs/basics/publishing-outputs.md
+++ b/docs/basics/publishing-outputs.md
@@ -22,15 +22,13 @@ The `pipeline.yml` does not yet have a git repo nor its write-access private key
 
 ![gist](/images/gist.png)
 
-Copy the "SSH" git URL:
+Click the "Embed" dropdown, select "Cone via SSH", and copy the git URL:
 
 ![ssh](/images/ssh.png)
 
-And paste it into the `pipeline.yml` file:
+And modify the `resource-git` section of `pipeline.yml`:
 
 ```
----
-resources:
 - name: resource-gist
   type: git
   source:


### PR DESCRIPTION
1. In the Introduction section, we run the command to create our initial Concourse CI environment:
`fly --target tutorial login --concourse-url http://127.0.0.1:8080 -u admin -p admin`
Later, we have a [basic-pipline section](https://concoursetutorial.com/basics/basic-pipeline/#login-to-concourse-web-ui) instructing the user to log in, with a parapgraph following stating authentication is disabled. Considering most users will be following the guide to set the specified username & password, I suggest removing the following paragraph.
> Why did you not have to enter any username/password? Excellent question, indeed. It's because your current fly -t tutorial deployment of Concourse has had authentication disabled. In a future lesson we will upgrade to a more robust installation of Concourse with passwords and fanciness.
2. Removed quotes from sample git URL for consistency.
3. Added commands to unpause and run pipelines and modified an existing command to following the same command order.
4. Improved wording for configuring SSH with GitHub Gist to improve discovery of the SSH dropdown and to notify the user a placeholder is exist and not to paste a whole new resource.