### PR TITLE
Fix nested list item indentation

### DIFF
--- a/docs/miscellaneous/versions-and-buildnumbers.md
+++ b/docs/miscellaneous/versions-and-buildnumbers.md
@@ -132,10 +132,10 @@ Its new value only exists within the job's build plan, being passed between cont
 There are [two options](https://github.com/concourse/semver-resource#version-bumping-semantics) for bumping a `semver` value when fetching it:
 
 * `bump`: Optional. Bump the version number semantically. The value must be one of:
-  * `major`: Bump the major version number, e.g. `1.0.0` -> `2.0.0`.
-  * `minor`: Bump the minor version number, e.g. `0.1.0` -> `0.2.0`.
-  * `patch`: Bump the patch version number, e.g. `0.0.1` -> `0.0.2`.
-  * `final`: Promote the version to a final version, e.g. `1.0.0-rc.1` -> `1.0.0`.
+    * `major`: Bump the major version number, e.g. `1.0.0` -> `2.0.0`.
+    * `minor`: Bump the minor version number, e.g. `0.1.0` -> `0.2.0`.
+    * `patch`: Bump the patch version number, e.g. `0.0.1` -> `0.0.2`.
+    * `final`: Promote the version to a final version, e.g. `1.0.0-rc.1` -> `1.0.0`.
 * `pre`: Optional. When bumping, bump to a prerelease (e.g. `rc` or `alpha`), or bump an existing prerelease.
 
 In the pipeline example above we `pre` bumped the `rc` number:


### PR DESCRIPTION
https://github.com/Python-Markdown/markdown/issues/3

_I did this directly in GitHub web ui and it doesn't let me exclude the end-of-file normalisation. That's why that last line shows up as a change as well._