### PR TITLE
remove useless subshell from date commands

### DIFF
--- a/docs/basics/publishing-outputs.md
+++ b/docs/basics/publishing-outputs.md
@@ -76,7 +76,7 @@ The `bump-timestamp-file` task runs the following `bump-timestamp-file.sh` scrip
 git clone resource-gist updated-gist
 
 cd updated-gist
-echo $(date) > bumpme
+date > bumpme
 
 git config --global user.email "nobody@concourse-ci.org"
 git config --global user.name "Concourse"

--- a/tutorials/basic/publishing-outputs/bump-timestamp-file.sh
+++ b/tutorials/basic/publishing-outputs/bump-timestamp-file.sh
@@ -6,7 +6,7 @@ set -x # print commands
 git clone resource-gist updated-gist
 
 cd updated-gist
-echo $(date) > bumpme
+date > bumpme
 
 git config --global user.email "nobody@concourse-ci.org"
 git config --global user.name "Concourse"


### PR DESCRIPTION
"echo $(date)" does the same thing as "date"