### PR TITLE
Added instructions to restart the Concourse server

### DIFF
--- a/docs/basics/task-hello-world.md
+++ b/docs/basics/task-hello-world.md
@@ -6,6 +6,14 @@ image_path: /images/build-output-hello-world.png
 
 The central concept of Concourse is to run tasks. You can run them directly from the command line as below, or from within pipeline jobs (as per every other section of the tutorial).
 
+From the same directory in which you previously deployed the Docker Concourse image (verify by running `ls -l` and looking for the `docker-compose.yml` file), start the local Concourse server.
+
+```
+docker-compose up
+```
+
+Now clone the Concourse Tutorial repo, switch to the task-hello-world directory, and run the command to execute the `task_hello_world.yml` task.
+
 ```
 git clone https://github.com/starkandwayne/concourse-tutorial.git
 cd concourse-tutorial/tutorials/basic/task-hello-world


### PR DESCRIPTION
Being new to both Concourse and Docker, it took me a bit to figure out I needed to restart Concourse in the local container after killing it at the end of the Introduction tutorial, and then a bit to figure out I had to do it from within the same directory.  Thought I'd try to help out other ignoramuses like myself.