### PR TITLE
Default credentials updated.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ In the spirit of declaring absolutely everything you do to get absolutely the sa
 First, alias it with a name `tutorial` (this name is used by all the tutorial task scripts).
 
 ```plain
-fly --target tutorial login --concourse-url http://127.0.0.1:8080 -u admin -p admin
+fly --target tutorial login --concourse-url http://127.0.0.1:8080 -u test -p test
 fly --target tutorial sync
 ```
 


### PR DESCRIPTION
Default credentials are now test/test: https://github.com/concourse/concourse-docker