### PR TITLE
Permission denied error note.

### DIFF
--- a/docs/basics/task-scripts.md
+++ b/docs/basics/task-scripts.md
@@ -40,3 +40,5 @@ Therefore its file `task_show_uname.sh` is available within the Concourse task c
 
 The only further requirement is that `task_show_uname.sh` is an executable script.
 
+Note: Make sure that the `task_show_uname.sh` is executable via `chmod +x task_show_uname.sh` to avoid permission denied error.
+


### PR DESCRIPTION
The error that comes up when the file does not have executable permissions. Backend error: Exit status: 500, message: {"Type":"","Message":"runc exec: exit status 1: exec failed: container_linux.go:345: starting container process caused \"exec: \\\"./task-scripts/task_show_uname.sh\\\": permission denied\"\n","Handle":"","ProcessID":"","Binary":""}
errored