### PR TITLE
Use git only image instead of full Concourse image

### DIFF
--- a/tutorials/basic/publishing-outputs/pipeline-missing-credentials.yml
+++ b/tutorials/basic/publishing-outputs/pipeline-missing-credentials.yml
@@ -23,7 +23,7 @@ jobs:
           platform: linux
           image_resource:
             type: docker-image
-            source: {repository: starkandwayne/concourse}
+            source: {repository: alpine/git}
 
           inputs:
             - name: resource-tutorial


### PR DESCRIPTION
For the `bump-timestamp-file.sh` script to run, we only need access to the `git` CLI, no need to download/use the entire concourse image.