### PR TITLE
Update task_show_uname.yml

### DIFF
--- a/tutorials/basic/task-scripts/task_show_uname.yml
+++ b/tutorials/basic/task-scripts/task_show_uname.yml
@@ -9,4 +9,5 @@ inputs:
   - name: task-scripts
 
 run:
-  path: ./task-scripts/task_show_uname.sh
+  path: /bin/sh
+  args: ["./task-scripts/task_show_uname.sh"]


### PR DESCRIPTION
Fix for windows users of this tutorial.

If you use this concourse tutorial on windows and run the task, it will not run:
$ fly -t tutorial e -c task_show_uname.yml
uploading task-scripts done
executing build 80 at http://concourse.poc/builds/80
initializing
running ./task-scripts/task_show_uname.sh
Backend error: Exit status: 500, message: {"Type":"","Message":"runc exec: exit status 1: exec failed: container_linux.go:346: starting container process caused "exec: \"./task-scripts/task_show_uname.sh\": permission denied"","Handle":"","ProcessID":"","Binary":""}

errored

This happens even in git bash you can see the properties correctly set-up:
$ ls -ltrh
total 3.0K
-rwxr-xr-x 1 amua 1049089 278 Jan 5 17:20 test.sh*
-rwxr-xr-x 1 amua 1049089 23 Jan 5 18:38 task_show_uname.sh*
-rw-r--r-- 1 amua 1049089 203 Jan 5 18:43 task_show_uname.yml