### PR TITLE
Update 404'ing Link In Hello World Docs

### DIFF
--- a/docs/basics/task-hello-world.md
+++ b/docs/basics/task-hello-world.md
@@ -93,7 +93,7 @@ Linux fdfa0821-fbc9-42bc-5f2f-219ff09d8ede 4.4.0-101-generic #124~14.04.1-Ubuntu
 succeeded
 ```
 
-The reason that you can select any base `image` (or `image_resource` when [configuring a task](http://concourse-ci.org/running-tasks.html)) is that this allows your task to have any prepared dependencies that it needs to run. Instead of installing dependencies each time during a task you might choose to pre-bake them into an `image` to make your tasks much faster.
+The reason that you can select any base `image_resource` (or `image` when [configuring a task execution with fly](https://concourse-ci.org/tasks.html#running-tasks)) is that this allows your task to have any prepared dependencies that it needs to run. Instead of installing dependencies each time during a task you might choose to pre-bake them into an `image` to make your tasks much faster.
 
 ## Miscellaneous
 


### PR DESCRIPTION
A link to the concourse documentation in the Hello World tutorial, under
the section "Task Docker Images" was returning a 404. Link has been
updated to the appropriate location.