### PR TITLE
Documented how to set external URL [#163]

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,15 @@ Thanks to everyone who visits our Stark & Wayne booth at conferences and says "T
                 - Go to Settings -> Daemon  -> Advanced -> Set the "experimental": true
                 - Restart Docker
                 - Switch to Linux container and restart the docker
-                
+    
+    If you are running concourse on a docker server, rather than your own machine, you need to set the external url env variable
+    inside the docker-compose.yml otherwise you will not be able to login to the webui because it wiull redirect to 127.0.0.1:8080
+    ```plain
+    - CONCOURSE_EXTERNAL_URL
+    + CONCOURSE_EXTERNAL_URL=http://{{my-server}}:8080
+    ```
+    You will also need to access the webui and setup the fly target on this url rather than 127.0.0.1, 
+    so change every http://127.0.0.1:8080 in this tutorial to http://{{my-server}}:8080         
 
 ### Test Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,20 +35,24 @@ Thanks to everyone who visits our Stark & Wayne booth at conferences and says "T
     wget https://raw.githubusercontent.com/starkandwayne/concourse-tutorial/master/docker-compose.yml
     docker-compose up -d
     ```
-    Following are the issues could face during windows 
-    a)      For windows amd issue . please follow below steps.
-                - Right click Docker instance
-                - Go to Settings -> Daemon  -> Advanced -> Set the "experimental": true
-                - Restart Docker
-                - Switch to Linux container and restart the docker
+    The following are common issues found when working with the tutorial 
     
-    If you are running concourse on a docker server, rather than your own machine, you need to set the external url env variable
-    inside the docker-compose.yml otherwise you will not be able to login to the webui because it wiull redirect to 127.0.0.1:8080
+    a. For Windows AMD issues:
+    
+    - Right click Docker instance
+    - Go to Settings -> Daemon  -> Advanced -> Set the "experimental": true
+    - Restart Docker
+    - Switch to Linux container and restart the docker
+    
+    b. For running concourse on a docker server instead of locally:
+    
+    You need to set the external url env variable inside the docker-compose.yml. Without this change you will not be able to login to 
+    the webui because it would redirect to 127.0.0.1:8080
     ```plain
     - CONCOURSE_EXTERNAL_URL
     + CONCOURSE_EXTERNAL_URL=http://{{my-server}}:8080
     ```
-    You will also need to access the webui and setup the fly target on this url rather than 127.0.0.1, 
+    You will also need to access the webui and setup the fly target to use this url rather than 127.0.0.1, 
     so change every http://127.0.0.1:8080 in this tutorial to http://{{my-server}}:8080         
 
 ### Test Setup


### PR DESCRIPTION
In order to make the tutorial flow more seamlessly, and not require users to troubleshoot the localhost redirects and env format etc I added a quick note to the documentation about to run this tutorial if the docker environment is in a Linux VM etc and the ports are not exposed on localhost.