### PR TITLE
fixed links to mkdocs standards

### DIFF
--- a/docs/basics/parameters.md
+++ b/docs/basics/parameters.md
@@ -84,7 +84,7 @@ fly -t tutorial sp -p parameters -c pipeline.yml -l credentials.yml
 
 ## Revisiting Publishing Outputs
 
-In the previous lesson [Publishing Outputs](/basics/publishing-outputs/), there were two user-provided changes to the `pipeline.yml`. These can now be changed to parameters.
+In the previous lesson [Publishing Outputs](publishing-outputs.md), there were two user-provided changes to the `pipeline.yml`. These can now be changed to parameters.
 
 ```
 cd ../publishing-outputs
@@ -146,4 +146,4 @@ There are two downsides to the two approaches above.
       path: env
     ```
 
-The solution to both of these problems is to use a Concourse Credentials Manager and is discussed in lesson [Secret with Credential Manager](/basics/secret-parameters/).
+The solution to both of these problems is to use a Concourse Credentials Manager and is discussed in lesson [Secret with Credential Manager](secret-parameters.md).

--- a/docs/basics/pipeline-jobs.md
+++ b/docs/basics/pipeline-jobs.md
@@ -37,7 +37,7 @@ fly -t tutorial sp -p publishing-outputs -c pipeline.yml -l ../publishing-output
 fly -t tutorial trigger-job -w -j publishing-outputs/job-bump-date
 ```
 
-If you are missing `../publishing-outputs/credentials.yml`, visit the section [Revisiting Publishing Outputs](/basics/parameters/#revisting-publishing-outputs) from the previous lesson.
+If you are missing `../publishing-outputs/credentials.yml`, visit the section [Revisiting Publishing Outputs](parameters.md#revisiting-publishing-outputs) from the previous lesson.
 
 The dashboard UI displays the additional job and its trigger/non-trigger resources. Importantly, it shows our first multi-job pipeline:
 

--- a/docs/basics/pipeline-resources.md
+++ b/docs/basics/pipeline-resources.md
@@ -7,13 +7,13 @@ It is very fast to iterate on a job's tasks by configuring them in the `pipeline
 
 The initial lessons introduced Tasks as standalone YAML files (which can be run via `fly execute`). Our `pipeline.yml` YAML files can be refactored to use these.
 
-Also in the earlier lesson [Task Scripts](/basics/task-scripts/) we looked at extracting complex `run` commands into standalone shell scripts.
+Also in the earlier lesson [Task Scripts](task-scripts.md) we looked at extracting complex `run` commands into standalone shell scripts.
 
 But with pipelines we now need to store the task file and task script somewhere outside of Concourse.
 
 Concourse offers no services for storing/retrieving your data. No git repositories. No blobstores. No build numbers. Every input and output must be provided externally. Concourse calls them "Resources". Example resources are `git`, `s3`, and `semver` respectively.
 
-See the Concourse documentation [Resource Types](https://concourse-ci.org/resource-types.html) for the list of built-in resource types and community resource types. Send messages to Slack. Bump a version number from 0.5.6 to 1.0.0. Create a ticket on Pivotal Tracker. It is all possible with Concourse resource types. The Concourse Tutorial's [Miscellaneous](/miscellaneous/) section also introduces some commonly useful Resource Types.
+See the Concourse documentation [Resource Types](https://concourse-ci.org/resource-types.html) for the list of built-in resource types and community resource types. Send messages to Slack. Bump a version number from 0.5.6 to 1.0.0. Create a ticket on Pivotal Tracker. It is all possible with Concourse resource types. The Concourse Tutorial's [Miscellaneous](../miscellaneous/) section also introduces some commonly useful Resource Types.
 
 The most common resource type to store our task files and task scripts is the `git` resource type. Perhaps your task files could be fetched via the `s3` resource type from an AWS S3 file; or the `archive` resource type to extract them from a remote archive file. Or perhaps the task files could be pre-baked into the `image_resource` base Docker image. But mostly you will use a `git` resource in your pipeline to pull in your pipeline task files.
 
@@ -88,7 +88,7 @@ jobs:
   ...
 ```
 
-Any fetched resource can now be an input to any task in the job build plan. As discussed in lessons [Task Inputs](/basics/task-inputs/) and [Task Scripts](/basics/task-scripts/) task inputs can be used as task scripts.
+Any fetched resource can now be an input to any task in the job build plan. As discussed in lessons [Task Inputs](task-inputs.md) and [Task Scripts](task-scripts.md) task inputs can be used as task scripts.
 
 The second step runs a user-defined task. The pipeline named the task `hello-world`. The task itself is not described in the pipeline. Instead it is described in a file `tutorials/basic/task-hello-world/task_hello_world.yml` from the `resource-tutorial` input.
 

--- a/docs/basics/publishing-outputs.md
+++ b/docs/basics/publishing-outputs.md
@@ -116,8 +116,8 @@ The Docker image being used is described in the `image_resources` section of the
 
 The Docker image [`starkandwayne/concourse`](https://hub.docker.com/r/starkandwayne/concourse) is described at https://github.com/starkandwayne/dockerfiles/ and is common base Docker image used by many Stark & Wayne pipelines.
 
-Your organisation may wish to curate its own base Docker images to be shared across pipelines. After finishing the Basics lessons, visit Lesson [Create and Use Docker Images](/miscellaneous/docker-images/) for creating pipelines to create your own Docker images using Concourse.
+Your organisation may wish to curate its own base Docker images to be shared across pipelines. After finishing the Basics lessons, visit Lesson [Create and Use Docker Images](../miscellaneous/docker-images.md) for creating pipelines to create your own Docker images using Concourse.
 
 ## Tragic Security
 
-If you're feeling ill from copying your private keys into a plain text file (`pipeline.yml`) and then seeing them printed to the screen (during `fly set-pipeline -c pipeline.yml`), then fear not. We will get to [Secret with Credential Manager](/basics/secret-parameters/) soon.
+If you're feeling ill from copying your private keys into a plain text file (`pipeline.yml`) and then seeing them printed to the screen (during `fly set-pipeline -c pipeline.yml`), then fear not. We will get to [Secret with Credential Manager](secret-parameters.md) soon.

--- a/docs/basics/task-hello-world.md
+++ b/docs/basics/task-hello-world.md
@@ -101,7 +101,7 @@ Linux fdfa0821-fbc9-42bc-5f2f-219ff09d8ede 4.4.0-101-generic #124~14.04.1-Ubuntu
 succeeded
 ```
 
-The reason that you can select any base `image` (or `image_resource` when [configuring a task](http://concourse-ci.org/running-tasks.html)) is that this allows your task to have any prepared dependencies that it needs to run. Instead of installing dependencies each time during a task you might choose to pre-bake them into an `image` to make your tasks much faster.
+The reason that you can select any base `image` (or `image_resource` when [configuring a task](http://concourse-ci.org/tasks.html#running-tasks)) is that this allows your task to have any prepared dependencies that it needs to run. Instead of installing dependencies each time during a task you might choose to pre-bake them into an `image` to make your tasks much faster.
 
 ## Miscellaneous
 

--- a/docs/basics/task-hello-world.md
+++ b/docs/basics/task-hello-world.md
@@ -105,4 +105,4 @@ The reason that you can select any base `image` (or `image_resource` when [confi
 
 ## Miscellaneous
 
-If you're interested in creating new Docker images using Concourse (of course you are), then there is a future section [Create and Use Docker Images](/miscellaneous/docker-images).
+If you're interested in creating new Docker images using Concourse (of course you are), then there is a future section [Create and Use Docker Images](../miscellaneous/docker-images.md).

--- a/docs/basics/task-outputs-to-inputs.md
+++ b/docs/basics/task-outputs-to-inputs.md
@@ -3,7 +3,7 @@ image_path: /images/pass-files.png
 
 # Passing Task Outputs to Task Inputs
 
-In the [previous lesson](/basics/job-inputs/) our task `web-app-tests` consumed an input resource and ran a script that ran some unit tests. The task did not create anything new. Some tasks will want to create something that is then passed to another task for further processing (this lesson); and some tasks will create something that is pushed back out to the external world ([next lesson](/basics/publishing-outputs/)).
+In the [previous lesson](job-inputs.md) our task `web-app-tests` consumed an input resource and ran a script that ran some unit tests. The task did not create anything new. Some tasks will want to create something that is then passed to another task for further processing (this lesson); and some tasks will create something that is pushed back out to the external world ([next lesson](publishing-outputs.md)).
 
 So far our pipelines' tasks' inputs have only come from resources using `get: resource-tutorial` build plan steps.
 

--- a/docs/basics/task-scripts.md
+++ b/docs/basics/task-scripts.md
@@ -7,7 +7,7 @@ The `inputs` feature of a task allows us to pass in two types of inputs:
 * requirements/dependencies to be processed/tested/compiled
 * task scripts to be executed to perform complex behavior
 
-A common pattern is for Concourse tasks to `run:` complex shell scripts rather than directly invoking commands as we did in the [Hello World tutorial](/basics/task-hello-world/#task-docker-images) (we ran `uname` command with arguments `-a`).
+A common pattern is for Concourse tasks to `run:` complex shell scripts rather than directly invoking commands as we did in the [Hello World tutorial](task-hello-world.md#task-docker-images) (we ran `uname` command with arguments `-a`).
 
 Let's refactor `task-hello-world/task_ubuntu_uname.yml` into a new task `task-scripts/task_show_uname.yml` with a separated task script `task-scripts/task_show_uname.sh`
 

--- a/docs/basics/trigger-jobs.md
+++ b/docs/basics/trigger-jobs.md
@@ -5,7 +5,7 @@ description: Review the four ways to trigger a job.
 There are four ways for a job to be triggered:
 
 * Clicking the `+` button on the web UI of a job (as we did in previous sections)
-* Input resource triggering a job (see the next lesson [Triggering Jobs with Resources](/basics/triggers/))
+* Input resource triggering a job (see the next lesson [Triggering Jobs with Resources](triggers.md))
 * `fly trigger-job -j pipeline/jobname` command
 * Sending `POST` HTTP request to Concourse API
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Learn to use https://concourse-ci.org with this linear sequence of tutorials. Le
 
 Concourse is a 100% open source CI/CD system with approximately 100 [integrations](https://resource-types.concourse-ci.org/) -- [Resource types](https://concourse-ci.org/resource-types.html) -- to the outside world. Concourse's principles reduce the risk of switching to and from Concourse, by encouraging practices that decouple your project from your CI's little details, and keeping all configuration in declarative files that can be checked into version control.
 
-This Concourse Tutorial book is the world's most popular guide for learning Concourse, since 2015. It is a wonderful companion for [Concourse online documentation](https://concourse-ci.org/index.html).
+This Concourse Tutorial book is the world's most popular guide for learning Concourse, since 2015. It is a wonderful companion for [Concourse online documentation](https://concourse-ci.org/docs.html).
 
 ## Thanks
 

--- a/docs/miscellaneous/index.md
+++ b/docs/miscellaneous/index.md
@@ -2,13 +2,13 @@
 
 This section contains miscellaneous lessons that follow on from the sequential Basic lessons.
 
-Using a Credentials Manager with Concourse is best practice, so from this point onwards the lessons will assume you are continuing to run `bucc` from the [Secrets with Credentials Manager](/basics/secret-parameters/) lesson. 
+Using a Credentials Manager with Concourse is best practice, so from this point onwards the lessons will assume you are continuing to run `bucc` from the [Secrets with Credentials Manager](../basics/secret-parameters.md) lesson. 
 
 Therefore the lessons will include `fly -t bucc` commands, rather than `fly -t tutorial` commands.
 
 Also, the lessons will instruct to run `credhub set` commands to populate parameters for your pipelines.
 
-You can of course use any Concourse, with or without a credentials manager. Adjust the `fly -t bucc` target alias for your target Concourse, and you can use `fly set-pipeline` with `-v` or `-l` flags to pass in parameters from the command line. Revisit lesson [Parameters](/basics/parameters/) to learn more.
+You can of course use any Concourse, with or without a credentials manager. Adjust the `fly -t bucc` target alias for your target Concourse, and you can use `fly set-pipeline` with `-v` or `-l` flags to pass in parameters from the command line. Revisit lesson [Parameters](../basics/parameters.md) to learn more.
 
 ## Abbreviated pipelines
 

--- a/docs/miscellaneous/run-tests-before-deploy.md
+++ b/docs/miscellaneous/run-tests-before-deploy.md
@@ -11,14 +11,14 @@ In this section we combine four ideas into a more advanced job:
 
 The resulting pipeline is a combination of the preceding lessons:
 
-* [Triggers](/basics/triggers/)
-* [Job Inputs](/basics/job-inputs/)
-* [Outputs to Inputs](/basics/task-outputs-to-inputs/)
-* [Secrets with Credentials Manager](/basics/secret-parameters/)
+* [Triggers](../basics/triggers.md)
+* [Job Inputs](../basics/job-inputs.md)
+* [Outputs to Inputs](../basics/task-outputs-to-inputs.md)
+* [Secrets with Credentials Manager](..//basics/secret-parameters.md)
 
 In the lesson we will deploy a sample Golang application to a Cloud Foundry platform. In your own Concourse pipelines you could deploy any application to any target platform.
 
-For convenience, we're reusing the `tutorials/basic/job-inputs/task-run-tests.sh` test script from lesson [Job Inputs](/basics/job-inputs/).
+For convenience, we're reusing the `tutorials/basic/job-inputs/task-run-tests.sh` test script from lesson [Job Inputs](..//basics/job-inputs.md).
 
 ```yaml
 - name: deploy-app
@@ -88,7 +88,7 @@ The `cf` resource deploys an application to Cloud Foundry. From the `pipeline.ym
     skip-cert-check: true
 ```
 
-As introduced in [Parameters](/basics/parameters/) and [Secrets with Credentials Manager](/basics/secret-parameters/)
+As introduced in [Parameters](../basics/parameters.md) and [Secrets with Credentials Manager](..//basics/secret-parameters.md)
 , the `((cf-api))` syntax is for late-binding variable, secret, or credential. This allows `pipeline.yml` to be generically useful and published in public. It also allows an operator to update variables in a central place and then all jobs will dynamically use the new variable values on demand.
 
 It is likely that `cf-api`, `cf-username`, `cf-password`, and `cf-organization` are common credentials for many pipelines, but `cf-space` might be specific to this pipeline. Example `credhub set` commands might be:

--- a/docs/miscellaneous/slack-notifications.md
+++ b/docs/miscellaneous/slack-notifications.md
@@ -193,7 +193,7 @@ jobs:
         text_file: notify_message/message
 ```
 
-Above, the `notify-message` folder is created by the `task: test-sometimes-works` step as an output, and consumed by `put: notify` resource. See the Basics section on [Passing task outputs to another task](/basics/task-outputs-to-inputs/) to revise this topic.
+Above, the `notify-message` folder is created by the `task: test-sometimes-works` step as an output, and consumed by `put: notify` resource. See the Basics section on [Passing task outputs to another task](../basics/task-outputs-to-inputs.md) to revise this topic.
 
 The `task: test-sometimes-works` step runs the `test-sometimes-works-notify-message.sh` script, which is the same as `test-sometimes-works.sh` but also creates a file `notify_message/message`.
 

--- a/docs/miscellaneous/slack-notifications.md
+++ b/docs/miscellaneous/slack-notifications.md
@@ -105,7 +105,7 @@ If you haven't already, add to your `pipeline.yml` the `resource_types` section 
 
 Next, we need to introduce the `on_failure` section of all build plan steps.
 
-Any `get`, `put`, or `task` step of a build plan can catch failures and do something interesting. From the [Concourse CI documentation](https://concourse-ci.org/on-failure-step-hook.html):
+Any `get`, `put`, or `task` step of a build plan can catch failures and do something interesting. From the [Concourse CI documentation](https://concourse-ci.org/jobs.html#schema.step.on_failure):
 
 ```yaml
 plan:

--- a/docs/miscellaneous/yaml-editors.md
+++ b/docs/miscellaneous/yaml-editors.md
@@ -1,6 +1,6 @@
 # Editors for Pipeline and Task yml's
 
-As the size of pipelines grow, it becomes very hard to edit yml's. Moreover, indentation and missed parameters causes error when pipeline line is set/executed. You can use [`validate-pipeline`](https://concourse-ci.org/setting-pipelines.html#fly-validate-pipeline.html) to verify but it would be better if we can have editors highlighing the error much before in development. This would be similar to IDE's highlighing syntax errors. This section will list editors you can use to edit yml's for concourse pipleines and tasks. 
+As the size of pipelines grow, it becomes very hard to edit yml's. Moreover, indentation and missed parameters causes error when pipeline line is set/executed. You can use [`validate-pipeline`](https://concourse-ci.org/setting-pipelines.html#fly-validate-pipeline) to verify but it would be better if we can have editors highlighing the error much before in development. This would be similar to IDE's highlighing syntax errors. This section will list editors you can use to edit yml's for concourse pipleines and tasks. 
 
 ## Visual Studio Code
 ---------------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
 ---
 site_name: Concourse Tutorial by Stark & Wayne
-pages:
+site_url: null
+use_directory_urls: false
+nav:
   - Basics:
       - Introduction: index.md
       - Hello World: basics/task-hello-world.md
@@ -58,4 +60,7 @@ repo_name: "help fix the tutorials"
 repo_url: "https://github.com/starkandwayne/concourse-tutorial"
 edit_uri: edit/master/docs/
 extra_css: [print.css, stylesheets/extra.css]
-google_analytics: ["UA-50822525-6", "concoursetutorial.com"]
+extra:
+  analytics:
+    provider: google
+    property: UA-XXXXXXXX-X


### PR DESCRIPTION
Fixing links to follow MKDOCS standards.   

+ pages should use relative markdown style to where the page is located (../basics/introduction.md) from the miscellaneous directory 
+ images use relative to the top of site standard   (/images/display.pin)