### PR TITLE
Use fly long commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Read the tutorial at https://concoursetutorial.com
 
 ## Thanks
 
-Thanks to Alex Suraci for inventing Concourse CI, and to Pivotal for sponsoring him and a team of developers to work since 2014.
+Thanks to Alex Suraci for inventing Concourse CI, and to Pivotal and VMWare for sponsoring him and a team of developers to work since 2014.
 
 At Stark & Wayne we started this tutorial as we were learning Concourse in early 2015, and we've been using Concourse in production since mid-2015 internally and at nearly all client projects.
 

--- a/docs/basics/basic-pipeline.md
+++ b/docs/basics/basic-pipeline.md
@@ -28,7 +28,7 @@ jobs:
             args: [hello world]
 ```
 
-You will be prompted to apply any configuration changes each time you run `fly set-pipeline` (or its alias `fly sp`)
+You will be prompted to apply any configuration changes each time you run `fly set-pipeline`.
 
 ```
 apply configuration? [yN]:
@@ -71,7 +71,7 @@ There are two ways to unpause (or re-pause) a pipeline.
 
     
 
-2. Using the `fly unpause-pipeline` command (or its alias `fly up`):
+2. Using the `fly unpause-pipeline` command:
 
     ```
     fly -t tutorial unpause-pipeline -p hello-world

--- a/docs/basics/job-inputs.md
+++ b/docs/basics/job-inputs.md
@@ -32,8 +32,8 @@ To run this task within a pipeline:
 
 ```
 cd ../job-inputs
-fly -t tutorial sp -p simple-app -c pipeline.yml
-fly -t tutorial up -p simple-app
+fly -t tutorial set-pipeline -p simple-app -c pipeline.yml
+fly -t tutorial unpause-pipeline -p simple-app
 ```
 
 View the pipeline UI http://127.0.0.1:8080/teams/main/pipelines/simple-app and notice that the job automatically starts.

--- a/docs/basics/parameters.md
+++ b/docs/basics/parameters.md
@@ -33,8 +33,8 @@ If we `fly set-pipeline` but do not provide the parameters, we see an error when
 
 ```
 cd ../parameters
-fly -t tutorial sp -p parameters -c pipeline.yml
-fly -t tutorial up -p parameters
+fly -t tutorial set-pipeline -p parameters -c pipeline.yml
+fly -t tutorial unpause-pipeline -p parameters
 fly -t tutorial trigger-job -j parameters/show-animal-names -w
 ```
 
@@ -49,7 +49,7 @@ errored
 ## Parameters from fly options
 
 ```
-fly -t tutorial sp -p parameters -c pipeline.yml -v cat-name=garfield -v dog-name=odie
+fly -t tutorial set-pipeline -p parameters -c pipeline.yml -v cat-name=garfield -v dog-name=odie
 fly -t tutorial trigger-job -j parameters/show-animal-names -w
 ```
 
@@ -79,7 +79,7 @@ YAML
 Use the `--load-vars-from` flag (aliased `-l`) to pass in this file instead of the `-v` flag. The following command should not modify the pipeline from the preceding step as the resulting pipeline YAML is equivalent.
 
 ```
-fly -t tutorial sp -p parameters -c pipeline.yml -l credentials.yml
+fly -t tutorial set-pipeline -p parameters -c pipeline.yml -l credentials.yml
 ```
 
 ## Revisiting Publishing Outputs
@@ -117,8 +117,8 @@ publishing-outputs-private-key: |-
 Use the `--load-vars-from` or `-l` flag to pass the variables into the parameters:
 
 ```
-fly -t tutorial sp -p publishing-outputs -c pipeline-parameters.yml -l credentials.yml
-fly -t tutorial up -p publishing-outputs
+fly -t tutorial set-pipeline -p publishing-outputs -c pipeline-parameters.yml -l credentials.yml
+fly -t tutorial unpause-pipeline -p publishing-outputs
 fly -t tutorial trigger-job -j publishing-outputs/job-bump-date
 ```
 

--- a/docs/basics/pipeline-jobs.md
+++ b/docs/basics/pipeline-jobs.md
@@ -33,7 +33,7 @@ Update the pipeline:
 
 ```
 cd ../pipeline-jobs
-fly -t tutorial sp -p publishing-outputs -c pipeline.yml -l ../publishing-outputs/credentials.yml
+fly -t tutorial set-pipeline -p publishing-outputs -c pipeline.yml -l ../publishing-outputs/credentials.yml
 fly -t tutorial trigger-job -w -j publishing-outputs/job-bump-date
 ```
 

--- a/docs/basics/pipeline-resources.md
+++ b/docs/basics/pipeline-resources.md
@@ -46,8 +46,8 @@ To deploy this change:
 
 ```
 cd ../pipeline-resources
-fly -t tutorial sp -c pipeline.yml -p hello-world
-fly -t tutorial up -p hello-world
+fly -t tutorial set-pipeline -c pipeline.yml -p hello-world
+fly -t tutorial unpause-pipeline -p hello-world
 ```
 
 The output will show the delta between the two pipelines and request confirmation. Type `y`. If successful, it will show:

--- a/docs/basics/pipeline-resources.md
+++ b/docs/basics/pipeline-resources.md
@@ -13,7 +13,7 @@ But with pipelines we now need to store the task file and task script somewhere 
 
 Concourse offers no services for storing/retrieving your data. No git repositories. No blobstores. No build numbers. Every input and output must be provided externally. Concourse calls them "Resources". Example resources are `git`, `s3`, and `semver` respectively.
 
-See the Concourse documentation [Resource Types](https://concourse-ci.org/resource-types.html) for the list of built-in resource types and community resource types. Send messages to Slack. Bump a version number from 0.5.6 to 1.0.0. Create a ticket on Pivotal Tracker. It is all possible with Concourse resource types. The Concourse Tutorial's [Miscellaneous](../miscellaneous/) section also introduces some commonly useful Resource Types.
+See the Concourse documentation [Resource Types](https://resource-types.concourse-ci.org) for the list of built-in resource types and community resource types. Send messages to Slack. Bump a version number from 0.5.6 to 1.0.0. Create a ticket on Pivotal Tracker. It is all possible with Concourse resource types. The Concourse Tutorial's [Miscellaneous](../miscellaneous/) section also introduces some commonly useful Resource Types.
 
 The most common resource type to store our task files and task scripts is the `git` resource type. Perhaps your task files could be fetched via the `s3` resource type from an AWS S3 file; or the `archive` resource type to extract them from a remote archive file. Or perhaps the task files could be pre-baked into the `image_resource` base Docker image. But mostly you will use a `git` resource in your pipeline to pull in your pipeline task files.
 

--- a/docs/basics/publishing-outputs.md
+++ b/docs/basics/publishing-outputs.md
@@ -8,8 +8,8 @@ So far we have used the `git` resource to fetch down a git repository, and used 
 ```
 cd ../publishing-outputs
 cp pipeline-missing-credentials.yml pipeline.yml
-fly -t tutorial sp -p publishing-outputs -c pipeline.yml
-fly -t tutorial up -p publishing-outputs
+fly -t tutorial set-pipeline -p publishing-outputs -c pipeline.yml
+fly -t tutorial unpause-pipeline -p publishing-outputs
 ```
 
 Pipeline dashboard http://127.0.0.1:8080/teams/main/pipelines/publishing-outputs shows that the input resource is erroring (see orange in key):
@@ -48,7 +48,7 @@ _Note: Please make sure that the key used here is not generated using a passphra
 Update the pipeline, force Concourse to quickly re-check the new Gist credentials, and then run the job:
 
 ```
-fly -t tutorial sp -p publishing-outputs -c pipeline.yml
+fly -t tutorial set-pipeline -p publishing-outputs -c pipeline.yml
 fly -t tutorial check-resource -r publishing-outputs/resource-gist
 fly -t tutorial trigger-job -j publishing-outputs/job-bump-date -w
 ```

--- a/docs/basics/secret-parameters.md
+++ b/docs/basics/secret-parameters.md
@@ -78,8 +78,8 @@ Back in your main `concourse-tutorial` terminal window, return to the `tutorials
 
 ```plain
 cd ../parameters
-fly -t bucc sp -p parameters -c pipeline.yml
-fly -t bucc up -p parameters
+fly -t bucc set-pipeline -p parameters -c pipeline.yml
+fly -t bucc unpause-pipeline -p parameters
 ```
 
 ## Insert values into Credentials Manager

--- a/docs/basics/task-inputs.md
+++ b/docs/basics/task-inputs.md
@@ -8,7 +8,7 @@ Consider the working directory of a task that explicitly has no inputs:
 
 ```
 cd ../task-inputs
-fly -t tutorial e -c no_inputs.yml
+fly -t tutorial execute -c no_inputs.yml
 ```
 
 The task runs `ls -al` to show the (empty) contents of the working folder inside the container:
@@ -20,8 +20,6 @@ drwxr-xr-x    2 root     root          4096 Feb 27 07:23 .
 drwxr-xr-x    3 root     root          4096 Feb 27 07:23 ..
 ```
 
-Note that above we used the short-hand form of the execute command in this example, simply **e**, as the action. Many commands have shortened single character forms, for example **fly s** is an alias for **fly sync**.
-
 In the example task `inputs_required.yml` we add a single input:
 
 ```yaml
@@ -32,7 +30,7 @@ inputs:
 When we try to execute the task:
 
 ```
-fly -t tutorial e -c inputs_required.yml
+fly -t tutorial execute -c inputs_required.yml
 ```
 
 It will fail:
@@ -44,7 +42,7 @@ error: missing required input `some-important-input`
 Commonly if wanting to run `fly execute` we will want to pass in the local folder (`.`). Use `-i name=path` option to configure each of the required `inputs`:
 
 ```
-fly -t tutorial e -c inputs_required.yml -i some-important-input=.
+fly -t tutorial execute -c inputs_required.yml -i some-important-input=.
 ```
 
 Now the `fly execute` command will upload the `.` directory as an input to the container. It will be made available at the path `some-important-input`:
@@ -78,6 +76,6 @@ The `fly execute -i` option can be removed if the current directory is the same 
 The task `input_parent_dir.yml` contains an input `task-inputs` which is also the current directory. All the contents in the directory `./task-inputs` will be uploaded to the docker image. So the following command will work and return the same results as above:
 
 ```
-fly -t tutorial e -c input_parent_dir.yml
+fly -t tutorial execute -c input_parent_dir.yml
 ```
 

--- a/docs/basics/task-outputs-to-inputs.md
+++ b/docs/basics/task-outputs-to-inputs.md
@@ -22,8 +22,8 @@ Subsequent tasks (discussed in this section) or resources (discussed in the next
 
 ```
 cd ../task-outputs-to-inputs
-fly -t tutorial sp -p pass-files -c pipeline.yml
-fly -t tutorial up -p pass-files
+fly -t tutorial set-pipeline -p pass-files -c pipeline.yml
+fly -t tutorial unpause-pipeline -p pass-files
 fly -t tutorial trigger-job -j pass-files/job-pass-files -w
 ```
 

--- a/docs/basics/task-scripts.md
+++ b/docs/basics/task-scripts.md
@@ -13,7 +13,7 @@ Let's refactor `task-hello-world/task_ubuntu_uname.yml` into a new task `task-sc
 
 ```
 cd ../task-scripts
-fly -t tutorial e -c task_show_uname.yml
+fly -t tutorial execute -c task_show_uname.yml
 ```
 
 The former specifies the latter as its task script:

--- a/docs/basics/triggers.md
+++ b/docs/basics/triggers.md
@@ -39,8 +39,8 @@ Now upgrade the `hello-world` pipeline with the `time` trigger and unpause it.
 
 ```
 cd ../triggers
-fly sp -t tutorial -c pipeline.yml -p hello-world
-fly up -t tutorial -p hello-world
+fly set-pipeline -t tutorial -c pipeline.yml -p hello-world
+fly unpause-pipeline -t tutorial -p hello-world
 ```
 
 This adds a new resource named `my-timer` which triggers `job-hello-world` approximately every 2 minutes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,9 @@ Thanks to everyone who visits our Stark & Wayne booth at conferences and says "T
 ## Getting Started
 
 1. Install [Docker](https://www.docker.com/community-edition).
-2. Install [Docker Compose](https://docs.docker.com/compose/install/#install-compose) if not included in your Docker installation.
+2. Install [Docker Compose](https://docs.docker.com/compose/install/#install-compose) if not included in your Docker installation. 
+While Docker's Compose V2 interface is still in beta, we will continue use the old docker-compose command line in this tutorial.
+We will leave it to the reader to mentally convert `docker-compose` to `docker compose` if want to use the Compose V2 interface
 3. Deploy Concourse using Docker Compose:
 
     ```plain
@@ -81,8 +83,8 @@ In the spirit of declaring absolutely everything you do to get absolutely the sa
 First, alias it with a name `tutorial` (this name is used by all the tutorial task scripts).
 
 ```plain
-fly --target tutorial login --concourse-url http://127.0.0.1:8080 -u admin -p admin
-fly --target tutorial sync
+fly --target=tutorial login --concourse-url=http://127.0.0.1:8080 --username=admin --password=admin
+fly --target=tutorial sync
 ```
 
 You can now see this saved target Concourse API in a local file:
@@ -106,6 +108,31 @@ targets:
 When we use the `fly` command we will target this Concourse API using `fly --target tutorial`.
 
 > @alexsuraci: I promise you'll end up liking it more than having an implicit target state :) Makes reusing commands from shell history much less dangerous (rogue fly configure can be bad)
+
+## Fly Help
+
+In keeping with the philosophy of clarity, all the fly commands in this tutorial will use the long form names for its command operations.
+If you get tired of typing out the command operation all the time, you can lookup the command's alias using fly help
+command. Most fly operations have an alias and as a bonus, you also get a short operation description!
+
+``` plain
+fly help
+```
+
+There are also long and short forms for options as well for fly operations.
+To see an operation's parameters and options place `--help` or `-h` after the operation parameter.
+
+``` plain
+fly login --help
+```
+Using option long forms as in the `fly login` command above, makes the command line hard to read, so we will use the short option forms
+in the remainder of this tutorial. Here is the login command again using the short option names.
+
+``` plain
+fly -t tutorial login --c http://127.0.0.1:8080 -u admin -p admin
+```
+
+Now, isn't that nicer to read and type!
 
 ## Destroy Concourse
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Thanks to everyone who visits our Stark & Wayne booth at conferences and says "T
 1. Install [Docker](https://www.docker.com/community-edition).
 2. Install [Docker Compose](https://docs.docker.com/compose/install/#install-compose) if not included in your Docker installation. 
 While Docker's Compose V2 interface is still in beta, we will continue use the old docker-compose command line in this tutorial.
-We will leave it to the reader to mentally convert `docker-compose` to `docker compose` if want to use the Compose V2 interface
+We will leave it to the reader to mentally convert `docker-compose` to `docker compose`.
 3. Deploy Concourse using Docker Compose:
 
     ```plain

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ This Concourse Tutorial book is the world's most popular guide for learning Conc
 
 ## Thanks
 
-Thanks to Alex Suraci for inventing Concourse CI, and to Pivotal for sponsoring him and a team of developers to work since 2014.
+Thanks to Alex Suraci for inventing Concourse CI, and to Pivotal and now VMWare for sponsoring him and a team of developers to work since 2014.
 
 At Stark & Wayne we started this tutorial as we were learning Concourse in early 2015, and we've been using Concourse in production since mid-2015 internally and at nearly all client projects.
 

--- a/docs/miscellaneous/docker-images.md
+++ b/docs/miscellaneous/docker-images.md
@@ -85,8 +85,8 @@ credhub set -n /concourse/main/docker-hub-password -t value -v yourpassword
 Then setup the pipeline and run the `publish` job:
 
 ```
-fly -t bucc sp -p push-docker-image -c pipeline.yml -n
-fly -t bucc up -p push-docker-image
+fly -t bucc set-pipeline -p push-docker-image -c pipeline.yml -n
+fly -t bucc unpause-pipeline -p push-docker-image
 fly -t bucc trigger-job -j push-docker-image/publish -w
 ```
 

--- a/docs/miscellaneous/github-release-input.md
+++ b/docs/miscellaneous/github-release-input.md
@@ -44,8 +44,8 @@ Try out this pipeline:
 
 ```
 cd tutorials/miscellaneous/github-release-input
-fly -t bucc sp -p github-release-input -c pipeline.yml
-fly -t bucc up -p github-release-input
+fly -t bucc set-pipeline -p github-release-input -c pipeline.yml
+fly -t bucc unpause-pipeline -p github-release-input
 fly -t bucc trigger-job -j github-release-input/shield -w
 ```
 

--- a/docs/miscellaneous/run-tests-before-deploy.md
+++ b/docs/miscellaneous/run-tests-before-deploy.md
@@ -62,9 +62,10 @@ This will fail due to missing parameters.
 
 ## Free Cloud Foundry for Lesson
 
-To complete this lesson you will need access to a Cloud Foundry. I'd like to suggest you try [Pivotal Web Services](https://run.pivotal.io/) which is run by Pivotal, the company who funds the core Concourse CI dev team. They offer free trial credit which will be more than sufficient for this lesson.
+To complete this lesson you will need access to a Cloud Foundry. 
 
-After signup, visit https://console.run.pivotal.io/, and after navigating to your "org", create a new "space" called `run-tests-before-deploy`. This lesson's pipeline will deploy a sample app into this space.
+
+After signup, login to your account and  navigate to your "org", create a new "space" called `run-tests-before-deploy`. This lesson's pipeline will deploy a sample app into this space.
 
 The sample application being deployed by the pipeline is https://github.com/cloudfoundry-community/simple-go-web-app
 
@@ -111,5 +112,3 @@ fly -t bucc trigger-job -j run-tests-before-deploy/deploy-app -w
 ## Cleanup
 
 You can now delete the sample app from your Cloud Foundry account.
-
-If you are using Pivotal Web Services, visit https://console.run.pivotal.io/ and navigate to the `run-tests-before-deploy` space to find your application and delete it.

--- a/docs/miscellaneous/slack-notifications.md
+++ b/docs/miscellaneous/slack-notifications.md
@@ -40,8 +40,8 @@ Create this pipeline and run the `test` job a few times. Sometimes it will succe
 
 ```
 cd tutorials/miscellaneous/slack-notifications
-fly -t bucc sp -p slack-notifications -c pipeline-no-notifications.yml
-fly -t bucc up -p slack-notifications
+fly -t bucc set-pipeline -p slack-notifications -c pipeline-no-notifications.yml
+fly -t bucc unpause-pipeline -p slack-notifications
 fly -t bucc trigger-job -j slack-notifications/test -w
 fly -t bucc trigger-job -j slack-notifications/test -w
 fly -t bucc trigger-job -j slack-notifications/test -w
@@ -136,7 +136,7 @@ We use the `on_failure` to invoke the `slack-notification` resource named `notif
 Update your pipeline and trigger the `test` job until you get a failure:
 
 ```
-fly -t bucc sp -p slack-notifications -c pipeline-slack-failures.yml
+fly -t bucc set-pipeline -p slack-notifications -c pipeline-slack-failures.yml
 fly -t bucc trigger-job -j slack-notifications/test -w
 ```
 
@@ -221,7 +221,7 @@ Visit https://api.slack.com/incoming-webhooks to learn more about contents of Sl
 To upgrade your pipeline and run the `test` job a few times to see success and failure notifications:
 
 ```
-fly -t bucc sp -p slack-notifications -c pipeline-dynamic-messages.yml
+fly -t bucc set-pipeline -p slack-notifications -c pipeline-dynamic-messages.yml
 fly -t bucc trigger-job -j slack-notifications/test -w
 fly -t bucc trigger-job -j slack-notifications/test -w
 fly -t bucc trigger-job -j slack-notifications/test -w
@@ -254,7 +254,7 @@ Also, we can condense the `on_success` and `on_failure` sections into a shared `
 To upgrade your pipeline and run the `test` job a few times to see success and failure notifications:
 
 ```
-fly -t bucc sp -p slack-notifications -c pipeline-custom-metadata.yml
+fly -t bucc set-pipeline -p slack-notifications -c pipeline-custom-metadata.yml
 fly -t bucc trigger-job -j slack-notifications/test -w
 fly -t bucc trigger-job -j slack-notifications/test -w
 fly -t bucc trigger-job -j slack-notifications/test -w

--- a/docs/miscellaneous/versions-and-buildnumbers.md
+++ b/docs/miscellaneous/versions-and-buildnumbers.md
@@ -110,8 +110,8 @@ The `version` resource will store the current SemVer value in a file `number`. T
 
 ```
 cd tutorials/mischellaneous/versions-and-buildnumbers
-fly -t bucc sp -p versions-and-buildnumbers -c pipeline-display-version.yml
-fly -t bucc up -p versions-and-buildnumbers
+fly -t bucc set-pipeline -p versions-and-buildnumbers -c pipeline-display-version.yml
+fly -t bucc unpause-pipeline -p versions-and-buildnumbers
 fly -t bucc trigger-job -j versions-and-buildnumbers/display-version -w
 ```
 
@@ -159,7 +159,7 @@ plan:
 Apply this change to our pipeline, and trigger the `bump-version` job a few times to see it increment the `0.0.1-rc.3` value:
 
 ```
-fly -t bucc sp -p versions-and-buildnumbers -c pipeline-bump-then-save.yml
+fly -t bucc set-pipeline -p versions-and-buildnumbers -c pipeline-bump-then-save.yml
 fly -t bucc trigger-job -j versions-and-buildnumbers/bump-version -w
 fly -t bucc trigger-job -j versions-and-buildnumbers/bump-version -w
 fly -t bucc trigger-job -j versions-and-buildnumbers/bump-version -w
@@ -176,8 +176,8 @@ Delete your pipeline and recreate it:
 ```
 fly -t bucc destroy-pipeline -p versions-and-buildnumbers
 
-fly -t bucc sp -p versions-and-buildnumbers -c pipeline-bump-then-save.yml
-fly -t bucc up -p versions-and-buildnumbers
+fly -t bucc set-pipeline -p versions-and-buildnumbers -c pipeline-bump-then-save.yml
+fly -t bucc unpause-pipeline -p versions-and-buildnumbers
 fly -t bucc trigger-job -j versions-and-buildnumbers/bump-version -w
 ```
 


### PR DESCRIPTION
As per issue #144 I have updated to use the long operational names.   I also added a section fly help and discussed the short operational names there.    Added changes about docker compose from docker-compose. 