### PR TITLE
Issue#260 change branche name to main

### DIFF
--- a/tutorials/basic/publishing-outputs/pipeline-missing-credentials.yml
+++ b/tutorials/basic/publishing-outputs/pipeline-missing-credentials.yml
@@ -8,7 +8,7 @@ resources:
   - name: resource-gist
     type: git
     source:
-      branch: master
+      branch: main
       uri:
       private_key:
 

--- a/tutorials/basic/publishing-outputs/pipeline-parameters.yml
+++ b/tutorials/basic/publishing-outputs/pipeline-parameters.yml
@@ -8,7 +8,7 @@ resources:
   - name: resource-gist
     type: git
     source:
-      branch: master
+      branch: main
       uri: ((publishing-outputs-gist-uri))
       private_key: ((publishing-outputs-private-key))
 


### PR DESCRIPTION
When creating new gists on github the default branch is called main instead of master
This was not reflected in the code. Which caused the tutorial to break.